### PR TITLE
Feat/prod capacity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,13 +32,14 @@ PROJECT_BASE_URL=https://godotassetlibrary.com
 # The driver always pools connections, but the pool is lazy: connections are
 # created on demand (minPoolSize 0), capped at MONGO_MAX_POOL, and idle ones
 # are pruned after MONGO_MAX_IDLE_MS. In cluster mode the default pool ceiling
-# is auto-scaled per worker (total ~1500 across all workers), so you normally
-# don't need to touch MONGO_MAX_POOL.
-# MONGO_MAX_POOL=1500        # explicit per-worker max connections (overrides the cluster auto-scale)
+# is auto-scaled per process (workers + primary; total ~1500 across the
+# cluster), so you normally don't need to touch MONGO_MAX_POOL.
+# MONGO_MAX_POOL=1500        # explicit per-process max connections (overrides the cluster auto-scale)
 # MONGO_MIN_POOL=0           # pre-warmed connections kept ready (default 0 = none; pure lazy)
 # MONGO_MAX_IDLE_MS=300000   # close idle connections after this many ms (default 5 min)
 # MAX_CONCURRENT_REQUESTS=500  # in-flight dynamic HTTP requests cap per worker (default 500; last-resort 503 backstop)
 # TELEMETRY_LOG_INTERVAL_MS=60000  # how often to log a telemetry snapshot (ms; default 60s)
+# METRICS_TOKEN=             # optional bearer token protecting GET /metrics (leave blank to keep it open)
 # ARGON2_MAX_CONCURRENCY=2
 
 # Import window (comma separated Godot versions the mirror imports)

--- a/.env.example
+++ b/.env.example
@@ -21,14 +21,24 @@ IMGPROXY_HOST=https://img.godotassetlibrary.com
 IMGPROXY_ENABLED=true
 PROJECT_BASE_URL=https://godotassetlibrary.com
 
-# Mongo pool / concurrency tuning (optional)
+# --- Cluster / concurrency / pooling tuning (optional) ---
+# Node cluster mode: the app forks WORKER_COUNT HTTP worker processes (each is
+# its own Node process using a CPU core), plus a primary that runs migrations,
+# index checks, sitemap generation and the cron jobs exactly once. Start with
+# WORKER_COUNT = your container's CPU allocation (leave unset to use the CPU
+# count, capped at 16).
+# WORKER_COUNT=4
+#
 # The driver always pools connections, but the pool is lazy: connections are
 # created on demand (minPoolSize 0), capped at MONGO_MAX_POOL, and idle ones
-# are pruned after MONGO_MAX_IDLE_MS.
-# MONGO_MAX_POOL=1000       # max connections per client (default 1000; high ceiling = "spin up as needed")
-# MONGO_MIN_POOL=0          # pre-warmed connections kept ready (default 0 = none; pure lazy)
-# MONGO_MAX_IDLE_MS=300000  # close idle connections after this many ms (default 5 min)
-# MAX_CONCURRENT_REQUESTS=100
+# are pruned after MONGO_MAX_IDLE_MS. In cluster mode the default pool ceiling
+# is auto-scaled per worker (total ~1500 across all workers), so you normally
+# don't need to touch MONGO_MAX_POOL.
+# MONGO_MAX_POOL=1500        # explicit per-worker max connections (overrides the cluster auto-scale)
+# MONGO_MIN_POOL=0           # pre-warmed connections kept ready (default 0 = none; pure lazy)
+# MONGO_MAX_IDLE_MS=300000   # close idle connections after this many ms (default 5 min)
+# MAX_CONCURRENT_REQUESTS=500  # in-flight dynamic HTTP requests cap per worker (default 500; last-resort 503 backstop)
+# TELEMETRY_LOG_INTERVAL_MS=60000  # how often to log a telemetry snapshot (ms; default 60s)
 # ARGON2_MAX_CONCURRENCY=2
 
 # Import window (comma separated Godot versions the mirror imports)

--- a/src/app/code/search/models/GET/GetAssetsCountFromQuery.ts
+++ b/src/app/code/search/models/GET/GetAssetsCountFromQuery.ts
@@ -1,8 +1,0 @@
-import { MongoHelper } from 'core/MongoHelper'
-import { buildSearchFilter, SearchFilterOptions } from './buildSearchFilter'
-
-export async function GetAssetsCountFromQuery (query: string, options: SearchFilterOptions = {}): Promise<number> {
-  const mongo = MongoHelper.getDatabase()
-  const filter = buildSearchFilter(query, options)
-  return await mongo.collection('assets').countDocuments(filter, { maxTimeMS: 5000 })
-}

--- a/src/app/code/search/models/GET/GetSearchFacets.ts
+++ b/src/app/code/search/models/GET/GetSearchFacets.ts
@@ -24,13 +24,80 @@ interface FacetSpec {
   omit: 'categories' | 'engines' | 'types' | 'supports'
 }
 
+const FACET_SPECS: FacetSpec[] = [
+  {
+    key: 'categories',
+    groupBy: '$category_lowercase',
+    labelBy: { $first: '$category' },
+    omit: 'categories'
+  },
+  { key: 'engines', groupBy: '$godot_version', omit: 'engines' },
+  { key: 'types', groupBy: '$type', omit: 'types' },
+  { key: 'supports', groupBy: '$support_level', omit: 'supports' }
+]
+
+const DIMENSION_KEYS: Array<FacetSpec['omit']> = ['categories', 'engines', 'types', 'supports']
+
+/** Filter for one facet with only its own dimension omitted (self-excluding). */
+function facetFilterFor (query: string, options: SearchFilterOptions, omit: FacetSpec['omit']): Record<string, any> {
+  return buildSearchFilter(query, {
+    categories: omit === 'categories' ? undefined : options.categories,
+    engines: omit === 'engines' ? undefined : options.engines,
+    types: omit === 'types' ? undefined : options.types,
+    supports: omit === 'supports' ? undefined : options.supports,
+    featured: options.featured
+  })
+}
+
+function groupStageFor (spec: FacetSpec): Record<string, any> {
+  const group: Record<string, any> = { _id: spec.groupBy, count: { $sum: 1 } }
+  if (spec.labelBy !== undefined) {
+    group.label = spec.labelBy
+  }
+  return { $group: group }
+}
+
+/** Normalize raw facet rows ({_id, count, label?}) into FacetGroup arrays. */
+function buildFacets (output: Record<string, any[]>): SearchFacets {
+  const facets: SearchFacets = { categories: [], engines: [], types: [], supports: [] }
+
+  for (const spec of FACET_SPECS) {
+    const rows = output[spec.key] ?? []
+    for (const item of rows) {
+      if (item._id == null) continue
+      const value = item._id as string
+      if (value === '') continue
+      facets[spec.key].push({
+        value,
+        label: (item.label as string | undefined) ?? value,
+        count: item.count as number
+      })
+    }
+  }
+
+  return facets
+}
+
 /**
- * Disjunctive (self-excluding) facets.
+ * Disjunctive (self-excluding) facets, consolidated to cut Mongo fan-out.
  *
- * Each facet runs its own aggregation that begins with the applicable $match,
- * which keeps a $text $match legal as the first stage on MongoDB 5. Omitting
- * only the facet's own dimension means a selected category does not collapse
- * the category facet, so users can still add alternate values.
+ * Each facet omits only its own dimension so counts stay self-excluding (a
+ * selected category does not collapse the category facet). Three shapes, in
+ * order of preference, to minimise round trips:
+ *
+ * 1. No dimension filter selected (categories/engines/types/supports all
+ *    empty) -> every facet filter is identical, so ONE outer `$match` (which
+ *    keeps `$text` legal as the first stage) feeds four `$group`
+ *    sub-pipelines in a single `$facet`.
+ * 2. Browsing (no `$text`) with filters selected -> the self-excluding
+ *    `$match` can live inside each `$facet` sub-pipeline, so all four facets
+ *    still run in one aggregation.
+ * 3. Text search with filters selected -> `$text` cannot appear inside `$facet`
+ *    sub-pipelines (it must be the first stage of its own pipeline), so each
+ *    facet runs as a separate aggregation.
+ *
+ * Result: 4 aggregations -> 1 for browse and for plain text searches (the
+ * common crawl/user paths), staying at 4 only for search + selected filters.
  */
 export async function GetSearchFacets (
   query: string,
@@ -39,54 +106,50 @@ export async function GetSearchFacets (
   const mongo = MongoHelper.getDatabase()
   const assets = mongo.collection('assets')
 
-  const specs: FacetSpec[] = [
-    {
-      key: 'categories',
-      groupBy: '$category_lowercase',
-      labelBy: { $first: '$category' },
-      omit: 'categories'
-    },
-    { key: 'engines', groupBy: '$godot_version', omit: 'engines' },
-    { key: 'types', groupBy: '$type', omit: 'types' },
-    { key: 'supports', groupBy: '$support_level', omit: 'supports' }
-  ]
+  const hasDimensionFilters = DIMENSION_KEYS.some(dim => (options[dim] ?? []).length > 0)
 
-  const results = await Promise.all(specs.map(async spec => {
-    // Omit only the facet's own dimension so counts stay self-excluding.
-    const facetOptions: SearchFilterOptions = {
-      categories: spec.omit === 'categories' ? undefined : options.categories,
-      engines: spec.omit === 'engines' ? undefined : options.engines,
-      types: spec.omit === 'types' ? undefined : options.types,
-      supports: spec.omit === 'supports' ? undefined : options.supports,
-      featured: options.featured
+  if (!hasDimensionFilters) {
+    // Strategy 1: all four facet filters are identical, so share one $match.
+    const filter = buildSearchFilter(query, options)
+    const facetStages: Record<string, any[]> = {}
+    for (const spec of FACET_SPECS) {
+      facetStages[spec.key] = [groupStageFor(spec)]
     }
-    const filter = buildSearchFilter(query, facetOptions)
+    const [doc] = await assets.aggregate([
+      { $match: filter },
+      { $facet: facetStages }
+    ]).maxTimeMS(5000).toArray()
+    return buildFacets(doc ?? {})
+  }
 
-    const group: Record<string, unknown> = { _id: spec.groupBy, count: { $sum: 1 } }
-    if (spec.labelBy !== undefined) group.label = spec.labelBy
+  if (query === '') {
+    // Strategy 2: browse with filters; each sub-pipeline has its own $match.
+    const facetStages: Record<string, any[]> = {}
+    for (const spec of FACET_SPECS) {
+      facetStages[spec.key] = [
+        { $match: facetFilterFor(query, options, spec.omit) },
+        groupStageFor(spec)
+      ]
+    }
+    const [doc] = await assets.aggregate([
+      { $facet: facetStages }
+    ]).maxTimeMS(5000).toArray()
+    return buildFacets(doc ?? {})
+  }
 
+  // Strategy 3: text search with filters selected -> separate aggregations.
+  const results = await Promise.all(FACET_SPECS.map(async spec => {
+    const filter = facetFilterFor(query, options, spec.omit)
     const pipeline: any[] = [
       { $match: filter },
-      { $group: group }
+      groupStageFor(spec)
     ]
-
     return await assets.aggregate(pipeline).maxTimeMS(5000).toArray()
   }))
 
-  const output: SearchFacets = { categories: [], engines: [], types: [], supports: [] }
-
-  specs.forEach((spec, index) => {
-    for (const item of results[index]) {
-      if (item._id == null) continue
-      const value = item._id as string
-      if (value === '') continue
-      output[spec.key].push({
-        value,
-        label: (item.label as string | undefined) ?? value,
-        count: item.count as number
-      })
-    }
+  const doc: Record<string, any[]> = {}
+  FACET_SPECS.forEach((spec, index) => {
+    doc[spec.key] = results[index]
   })
-
-  return output
+  return buildFacets(doc)
 }

--- a/src/app/code/search/models/GET/GetSearchResults.ts
+++ b/src/app/code/search/models/GET/GetSearchResults.ts
@@ -5,6 +5,11 @@ import { buildSearchFilter, SearchFilterOptions } from './buildSearchFilter'
 
 interface ReturnedAssets extends WithId<Document>, assetGridSchema {}
 
+export interface SearchResults {
+  assets: ReturnedAssets[]
+  total: number
+}
+
 const SEARCH_FIELDS_PROJECTION: Record<string, number> = {
   category: 1,
   godot_version: 1,
@@ -41,13 +46,28 @@ function mongoSortFor (sortKey: string): Record<string, any> {
   return { modify_date_at: -1, asset_id: 1 }
 }
 
-export async function GetAssetsFromQuery (
+/**
+ * Fetch one page of results AND the total match count in a single aggregation.
+ *
+ * Replaces the old pair of `find()` + `countDocuments()` (2 round trips) with
+ * one `$facet`: the `$match` runs once and its output feeds both the paged
+ * `results` sub-pipeline (sort/skip/limit/project) and a `total` count
+ * sub-pipeline. This halves the per-request Mongo fan-out on the busiest
+ * discovery route, which directly relieves the connection-pool pressure that
+ * caused the prod 503s.
+ *
+ * The `$match` stays the first stage of the outer pipeline, which is what
+ * keeps `$text` legal (a `$text` `$match` must be first) and lets the
+ * `results` sub-pipeline sort/project by `{ $meta: 'textScore' }` for the
+ * relevance sort. Verified against MongoDB 5.
+ */
+export async function GetSearchResults (
   query: string,
   limit: number,
   skip: number,
   sortKey: string,
   options: SearchFilterOptions = {}
-): Promise<ReturnedAssets[]> {
+): Promise<SearchResults> {
   const mongo = MongoHelper.getDatabase()
   const filter = buildSearchFilter(query, options)
 
@@ -56,16 +76,25 @@ export async function GetAssetsFromQuery (
     projection.score = { $meta: 'textScore' }
   }
 
-  const operationObject = await mongo.collection('assets').find(filter, {
-    limit,
-    sort: mongoSortFor(sortKey),
-    projection,
-    maxTimeMS: 5000
-  }).skip(skip).toArray() as ReturnedAssets[]
+  const pipeline: any[] = [
+    { $match: filter },
+    {
+      $facet: {
+        results: [
+          { $sort: mongoSortFor(sortKey) },
+          { $skip: skip },
+          { $limit: limit },
+          { $project: projection }
+        ],
+        total: [{ $count: 'count' }]
+      }
+    }
+  ]
 
-  if (operationObject === null || operationObject === undefined) {
-    throw new Error('No assets found')
+  const [doc] = await mongo.collection('assets').aggregate(pipeline).maxTimeMS(5000).toArray()
+
+  return {
+    assets: ((doc?.results as any[]) ?? []) as ReturnedAssets[],
+    total: ((doc?.total?.[0]?.count as number | undefined) ?? 0)
   }
-
-  return operationObject
 }

--- a/src/app/code/search/services/SearchService.ts
+++ b/src/app/code/search/services/SearchService.ts
@@ -2,8 +2,7 @@ import { Request, Response } from 'express'
 import { TokenServices } from 'core/modules/authentication/services/TokenServices'
 import { GetUserSavedAssets } from 'app/code/dashboard/models/GET/GetUserSavedAssets'
 import striptags from 'striptags'
-import { GetAssetsCountFromQuery } from '../models/GET/GetAssetsCountFromQuery'
-import { GetAssetsFromQuery } from '../models/GET/GetAssetsFromQuery'
+import { GetSearchResults } from '../models/GET/GetSearchResults'
 import { GetSearchFacets } from '../models/GET/GetSearchFacets'
 import { GetRelatedAssets } from 'app/code/asset/models/GET/GetRelatedAssets'
 import { SearchFilterOptions } from '../models/GET/buildSearchFilter'
@@ -27,11 +26,15 @@ export class SearchService {
       featured: parsed.featured
     }
 
-    const [assets, totalAssetsForQuery, facets] = await Promise.all([
-      GetAssetsFromQuery(parsed.query, parsed.limit, parsed.skip, parsed.sort, filterOptions),
-      GetAssetsCountFromQuery(parsed.query, filterOptions),
+    // Results + total count now come from ONE aggregation ($facet) and the
+    // four facets are consolidated into another, so the per-request Mongo
+    // fan-out drops from ~6 operations to ~2, directly relieving the pool
+    // pressure that caused the prod 503s.
+    const [searchData, facets] = await Promise.all([
+      GetSearchResults(parsed.query, parsed.limit, parsed.skip, parsed.sort, filterOptions),
       GetSearchFacets(parsed.query, filterOptions)
     ])
+    const { assets, total: totalAssetsForQuery } = searchData
 
     attachCardExtras(assets)
 

--- a/src/core/MongoHelper.ts
+++ b/src/core/MongoHelper.ts
@@ -1,5 +1,6 @@
 import { MongoClient, Db } from 'mongodb'
 import { logger } from 'core/utils/logger'
+import { getDefaultMongoPool } from 'core/utils/clusterConfig'
 
 export class MongoHelper {
   private static instance: MongoHelper
@@ -54,19 +55,19 @@ export class MongoHelper {
     const url = `mongodb://${process.env.DB_USERNAME}:${process.env.DB_PASSWORD}@${process.env.DB_HOST}:${process.env.DB_PORT}/${process.env.DB_NAME}?authSource=admin`
 
     try {
-      // Traditional long-running web server (single instance). Connections are
-      // created lazily on demand (minPoolSize 0) and pruned when idle, so the
-      // pool "spins up as needed" rather than holding connections. Each search
-      // request fans out ~6 concurrent queries (4 facet aggregations + results
-      // + count) and the homepage ~4. RouterServer caps concurrent HTTP
-      // requests at MAX_CONCURRENT_REQUESTS (default 100), so the worst-case
-      // simultaneous connection demand is ~600; a 1000 ceiling leaves headroom
-      // while still protecting the MongoDB server. Idle connections are reaped
-      // after MONGO_MAX_IDLE_MS, so steady state stays low. Tune with
-      // MONGO_MAX_POOL. The 5s wait-queue timeout stays as a fail-fast
-      // backstop for genuine overload.
+      // Traditional long-running web server. Connections are created lazily on
+      // demand (minPoolSize 0) and pruned when idle, so the pool "spins up as
+      // needed" rather than holding connections. Search requests now run 2
+      // MongoDB ops instead of 6 (results+count and all four facets are
+      // consolidated into $facet aggregations) and the homepage ~4. Under
+      // cluster mode every worker owns its own pool, so the default ceiling is
+      // scaled per worker (clusterConfig) to keep the TOTAL worst-case
+      // connections bounded (~1500) no matter how many workers run; an
+      // explicit MONGO_MAX_POOL always wins. Idle connections are reaped after
+      // MONGO_MAX_IDLE_MS, so steady state stays low. The 5s wait-queue
+      // timeout stays as a fail-fast backstop for genuine overload.
       const parsedMax = Number.parseInt(process.env.MONGO_MAX_POOL ?? '', 10)
-      const maxPoolSize = Number.isFinite(parsedMax) && parsedMax > 0 ? parsedMax : 1000
+      const maxPoolSize = Number.isFinite(parsedMax) && parsedMax > 0 ? parsedMax : getDefaultMongoPool()
 
       // 0 = no pre-warmed connections; each one is established on first use.
       const parsedMin = Number.parseInt(process.env.MONGO_MIN_POOL ?? '', 10)

--- a/src/core/MongoHelper.ts
+++ b/src/core/MongoHelper.ts
@@ -60,9 +60,10 @@ export class MongoHelper {
       // needed" rather than holding connections. Search requests now run 2
       // MongoDB ops instead of 6 (results+count and all four facets are
       // consolidated into $facet aggregations) and the homepage ~4. Under
-      // cluster mode every worker owns its own pool, so the default ceiling is
-      // scaled per worker (clusterConfig) to keep the TOTAL worst-case
-      // connections bounded (~1500) no matter how many workers run; an
+      // cluster mode every worker AND the primary owns its own pool, so the
+      // default ceiling is scaled per process (clusterConfig) to keep the
+      // TOTAL worst-case connections bounded (~1500) no matter how many
+      // workers run; an
       // explicit MONGO_MAX_POOL always wins. Idle connections are reaped after
       // MONGO_MAX_IDLE_MS, so steady state stays low. The 5s wait-queue
       // timeout stays as a fail-fast backstop for genuine overload.

--- a/src/core/RouterServer.ts
+++ b/src/core/RouterServer.ts
@@ -13,15 +13,35 @@ import { generateProxyUrl } from 'core/utils/generateProxyUrl'
 import { buildAssetUrl, buildAssetUrlWithReturn } from 'core/utils/assetUrl'
 import { buildCategoryPath, buildEnginePath } from 'core/utils/taxonomyUrl'
 import { safeJsonLd } from 'core/utils/jsonLd'
+import * as telemetry from 'core/utils/telemetry'
 require('express-async-errors')
 
 let promoCachedMessage: string | null = null
 let promoCacheExpiresAt = 0
 let promoRefresh: Promise<void> | null = null
 const PROMO_TTL_MS = 60_000
+
+// Cap on in-flight dynamic HTTP requests (process-wide). This is the "Server
+// is busy" 503 backstop, and it was the actual cause of the prod 503s: at
+// ~46 req/s (120M/month) a cap of 100 saturates whenever the average request
+// takes more than ~2.2s, which bursts easily reach while crawling. Raised to
+// 500 in tandem with the search fan-out consolidation (6 -> 2 Mongo ops per
+// request) and the MONGO_MAX_POOL bump, so worst-case pool demand stays
+// bounded (~cap x 2). Tune with MAX_CONCURRENT_REQUESTS and watch
+// /metrics http_peak_active_requests + http_requests_rejected_active_cap_total.
 const parsedMaxRequests = Number.parseInt(process.env.MAX_CONCURRENT_REQUESTS ?? '', 10)
-const MAX_CONCURRENT_REQUESTS = Number.isFinite(parsedMaxRequests) && parsedMaxRequests > 0 ? parsedMaxRequests : 100
+const MAX_CONCURRENT_REQUESTS = Number.isFinite(parsedMaxRequests) && parsedMaxRequests > 0 ? parsedMaxRequests : 500
+
+const parsedTelemetryInterval = Number.parseInt(process.env.TELEMETRY_LOG_INTERVAL_MS ?? '', 10)
+const TELEMETRY_LOG_INTERVAL_MS = Number.isFinite(parsedTelemetryInterval) && parsedTelemetryInterval > 0 ? parsedTelemetryInterval : 60_000
+
 let activeRequests = 0
+
+// Throttle the per-rejection log so a sustained overload burst can't flood
+// Docker's log driver while the server is already under pressure.
+const REJECT_LOG_INTERVAL_MS = 5000
+let lastRejectLogAt = 0
+let rejectedSinceLastLog = 0
 
 function refreshPromoMessage (): void {
   if (promoRefresh !== null) {
@@ -118,9 +138,36 @@ class RouterServer extends Server {
       res.send('OK')
     })
 
+    // Prometheus-format telemetry. Registered before the active-request cap so
+    // it stays reachable while the app is under load, like /health.
+    this.app.get('/metrics', (_req: Request, res: Response) => {
+      res.set('Content-Type', 'text/plain; version=0.0.4; charset=utf-8')
+      res.set('Cache-Control', 'no-store')
+      res.send(telemetry.prometheusText())
+    })
+
     // Bound request state retained during traffic spikes or database pressure.
-    this.app.use((_req: Request, res: Response, next: NextFunction) => {
+    // Every admitted request is timed and recorded by telemetry; rejections
+    // increment a counter and are logged (throttled) so capacity limits stay
+    // visible in the logs and on /metrics.
+    this.app.use((req: Request, res: Response, next: NextFunction) => {
+      telemetry.requestStart()
+
       if (activeRequests >= MAX_CONCURRENT_REQUESTS) {
+        telemetry.requestRejectedByActiveCap()
+        rejectedSinceLastLog++
+        const now = Date.now()
+        if (now - lastRejectLogAt >= REJECT_LOG_INTERVAL_MS) {
+          lastRejectLogAt = now
+          logger.log('warn', `Rejected ${rejectedSinceLastLog} request(s) at the active-request cap`, {
+            active: activeRequests,
+            max: MAX_CONCURRENT_REQUESTS,
+            method: req.method,
+            path: req.path,
+            ua: req.get('user-agent')
+          })
+          rejectedSinceLastLog = 0
+        }
         res.setHeader('Retry-After', '1')
         res.status(StatusCodes.SERVICE_UNAVAILABLE).send({ error: 'Server is busy, please try again shortly' })
         return
@@ -128,10 +175,12 @@ class RouterServer extends Server {
 
       activeRequests++
       let released = false
+      const startedAt = Date.now()
       const release = (): void => {
         if (!released) {
           released = true
           activeRequests--
+          telemetry.requestEnd(Date.now() - startedAt, res.statusCode)
         }
       }
       res.once('finish', release)
@@ -210,6 +259,16 @@ class RouterServer extends Server {
     this.app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
       logger.log('error', err.message, [err])
 
+      // Track MongoDB pool / topology health separately from HTTP errors so
+      // capacity tuning is driven by numbers, not guesses.
+      const errorName = (err as any)?.name ?? ''
+      const errorMessage = typeof (err as any)?.message === 'string' ? (err as any).message : ''
+      if (errorName === 'MongoWaitQueueTimeoutError' || /connection pool/i.test(errorMessage)) {
+        telemetry.recordMongoWaitQueueTimeout()
+      } else if (errorName === 'MongoServerSelectionError' || /server selection/i.test(errorMessage)) {
+        telemetry.recordMongoServerSelectionError()
+      }
+
       // Explicit status codes (e.g. BadRequestError) are honored; anything
       // else is a server error, not a client error.
       const statusCode = (err as any).statusCode ?? StatusCodes.INTERNAL_SERVER_ERROR
@@ -267,6 +326,7 @@ class RouterServer extends Server {
     })
 
     this.app.listen(port, () => {
+      telemetry.startPeriodicLogging(TELEMETRY_LOG_INTERVAL_MS)
       logger.log('info', `Running on port: ${port}`)
     })
   }

--- a/src/core/RouterServer.ts
+++ b/src/core/RouterServer.ts
@@ -139,8 +139,17 @@ class RouterServer extends Server {
     })
 
     // Prometheus-format telemetry. Registered before the active-request cap so
-    // it stays reachable while the app is under load, like /health.
-    this.app.get('/metrics', (_req: Request, res: Response) => {
+    // it stays reachable while the app is under load, like /health. Process and
+    // system metrics are only sensitive if someone can reach this route, so it
+    // is gated behind an optional bearer token for production; leaving
+    // METRICS_TOKEN unset keeps it open (e.g. local dev).
+    this.app.get('/metrics', (req: Request, res: Response) => {
+      const metricsToken = process.env.METRICS_TOKEN
+      if (metricsToken !== undefined && metricsToken !== '' &&
+          req.get('authorization') !== `Bearer ${metricsToken}`) {
+        res.status(StatusCodes.FORBIDDEN).send('Forbidden')
+        return
+      }
       res.set('Content-Type', 'text/plain; version=0.0.4; charset=utf-8')
       res.set('Cache-Control', 'no-store')
       res.send(telemetry.prometheusText())
@@ -151,9 +160,10 @@ class RouterServer extends Server {
     // increment a counter and are logged (throttled) so capacity limits stay
     // visible in the logs and on /metrics.
     this.app.use((req: Request, res: Response, next: NextFunction) => {
-      telemetry.requestStart()
-
       if (activeRequests >= MAX_CONCURRENT_REQUESTS) {
+        // Rejected requests never enter telemetry's active gauge or totals, so
+        // http_peak_active_requests can't exceed the cap and http_requests_total
+        // only counts work the server actually admitted.
         telemetry.requestRejectedByActiveCap()
         rejectedSinceLastLog++
         const now = Date.now()
@@ -173,6 +183,7 @@ class RouterServer extends Server {
         return
       }
 
+      telemetry.requestStart()
       activeRequests++
       let released = false
       const startedAt = Date.now()

--- a/src/core/start.ts
+++ b/src/core/start.ts
@@ -1,3 +1,4 @@
+import cluster from 'cluster'
 import RouterServer from 'core/RouterServer'
 import { MongoHelper } from 'core/MongoHelper'
 import { logger } from 'core/utils/logger'
@@ -5,47 +6,7 @@ import * as cronJobs from 'core/jobs.index'
 import { ensureIndexes } from 'core/ensureIndexes'
 import { runMigrations } from 'core/migrations'
 import { runGenerateSitemap } from 'app/utilities/sitemapGenerator/jobs/generateSitemap'
-
-// Connect to MongoDB Database
-MongoHelper.getInstance().connect().then(async () => {
-  const startTime: Date = new Date()
-  logger.log('info', `Successfull startup at ${startTime}`)
-
-  // Apply any pending migrations before verifying indexes. This is idempotent:
-  // already-applied migrations are skipped via the `migrations` collection, so
-  // it is a no-op on every normal boot. Failures are logged but do not block
-  // serving — ensureIndexes still runs as the safety net.
-  try {
-    await runMigrations(MongoHelper.getDatabase())
-  } catch (error: any) {
-    logger.log('error', `Migrations failed at startup: ${error?.message ?? error}`, [error])
-  }
-
-  await ensureIndexes()
-
-  // A fresh deployment has no sitemap until the 02:00 cron runs. Generate it
-  // now (best-effort, non-blocking) so robots.txt never advertises a missing
-  // file. The daily cron still refreshes it.
-  try {
-    await runGenerateSitemap()
-  } catch (error: any) {
-    logger.log('error', `Startup sitemap generation failed: ${error?.message ?? error}`, [error])
-  }
-
-  // Start our server
-  const server: RouterServer = new RouterServer()
-  server.start(3000)
-
-  // init all our cron jobs
-  for (const name of Object.keys(cronJobs)) {
-    const job = (cronJobs as any)[name]
-    if (typeof job === 'object') {
-      job.start()
-    }
-  }
-}).catch(error => {
-  logger.log('error', 'Error durring startup', error)
-})
+import { getWorkerCount } from 'core/utils/clusterConfig'
 
 process.on('uncaughtException', (err) => {
   console.error('Uncaught Exception:', err)
@@ -56,3 +17,88 @@ process.on('unhandledRejection', (reason) => {
   console.error('Unhandled Rejection:', reason)
   process.exit(1)
 })
+
+// Node cluster: the PRIMARY process does the one-time bootstrap (Mongo
+// connect, migrations, index checks, sitemap), runs every cron job exactly
+// once, and supervises the HTTP workers. Each WORKER is its own Node process
+// that just connects to MongoDB and serves HTTP, so the app can use every CPU
+// core instead of the single thread of one process. This is what lets prod
+// absorb the load that used to saturate one process and trip the 503 cap.
+if (cluster.isPrimary) {
+  MongoHelper.getInstance().connect().then(async () => {
+    const startTime: Date = new Date()
+    logger.log('info', `Primary startup at ${startTime}`)
+
+    // One-time, primary-only bootstrap. Migrations are idempotent (already
+    // applied ones are skipped via the `migrations` collection); failures are
+    // logged but never block serving — ensureIndexes stays the safety net.
+    try {
+      await runMigrations(MongoHelper.getDatabase())
+    } catch (error: any) {
+      logger.log('error', `Migrations failed at startup: ${error?.message ?? error}`, [error])
+    }
+
+    await ensureIndexes()
+
+    // A fresh deployment has no sitemap until the 02:00 cron runs. Generate it
+    // now (best-effort) so robots.txt never advertises a missing file.
+    try {
+      await runGenerateSitemap()
+    } catch (error: any) {
+      logger.log('error', `Startup sitemap generation failed: ${error?.message ?? error}`, [error])
+    }
+
+    // Cron jobs run once, in the primary, so N workers never run the same
+    // import / README / sitemap / token-cleanup job concurrently.
+    for (const name of Object.keys(cronJobs)) {
+      const job = (cronJobs as any)[name]
+      if (typeof job === 'object') {
+        job.start()
+      }
+    }
+
+    // Fork the HTTP workers after bootstrap so no worker ever serves before
+    // migrations/indexes have been attempted.
+    const workerCount = getWorkerCount()
+    for (let i = 0; i < workerCount; i++) {
+      cluster.fork()
+    }
+    logger.log('info', `Forked ${workerCount} worker(s)`)
+
+    // Auto-heal: replace a worker that crashed or was killed. A short delay
+    // avoids a tight refork loop if something is wrong at boot.
+    cluster.on('exit', (worker, code, signal) => {
+      logger.log('warn', `Worker ${worker.process.pid} exited (code=${code}, signal=${signal}); forking replacement`)
+      setTimeout(() => {
+        cluster.fork()
+      }, 1000)
+    })
+
+    // Let Docker/systemd stop the cluster cleanly.
+    const shutdown = (): void => {
+      logger.log('info', 'Primary shutting down; terminating workers')
+      for (const id of Object.keys(cluster.workers ?? {})) {
+        cluster.workers?.[id]?.kill('SIGTERM')
+      }
+      MongoHelper.getInstance().disconnect()
+      process.exit(0)
+    }
+    process.on('SIGTERM', shutdown)
+    process.on('SIGINT', shutdown)
+  }).catch(error => {
+    logger.log('error', 'Error during primary startup', error)
+    process.exit(1)
+  })
+} else {
+  // Worker: connect to MongoDB and serve HTTP only. No migrations, index
+  // checks, sitemap generation or cron here — those run once in the primary.
+  MongoHelper.getInstance().connect().then(() => {
+    const startTime: Date = new Date()
+    logger.log('info', `Worker ${process.pid} ready at ${startTime}`)
+    const server: RouterServer = new RouterServer()
+    server.start(3000)
+  }).catch(error => {
+    logger.log('error', `Error during worker ${process.pid} startup`, error)
+    process.exit(1)
+  })
+}

--- a/src/core/start.ts
+++ b/src/core/start.ts
@@ -66,16 +66,29 @@ if (cluster.isPrimary) {
     logger.log('info', `Forked ${workerCount} worker(s)`)
 
     // Auto-heal: replace a worker that crashed or was killed. A short delay
-    // avoids a tight refork loop if something is wrong at boot.
+    // avoids a tight refork loop if something is wrong at boot, and reforking
+    // is suppressed during an intentional shutdown so we never spin up workers
+    // that were just SIGTERM'd.
+    let shuttingDown = false
     cluster.on('exit', (worker, code, signal) => {
+      if (shuttingDown) {
+        return
+      }
       logger.log('warn', `Worker ${worker.process.pid} exited (code=${code}, signal=${signal}); forking replacement`)
       setTimeout(() => {
-        cluster.fork()
+        if (!shuttingDown) {
+          cluster.fork()
+        }
       }, 1000)
     })
 
-    // Let Docker/systemd stop the cluster cleanly.
+    // Let Docker/systemd stop the cluster cleanly. Idempotent so a SIGTERM and
+    // SIGINT arriving together only trigger one shutdown.
     const shutdown = (): void => {
+      if (shuttingDown) {
+        return
+      }
+      shuttingDown = true
       logger.log('info', 'Primary shutting down; terminating workers')
       for (const id of Object.keys(cluster.workers ?? {})) {
         cluster.workers?.[id]?.kill('SIGTERM')

--- a/src/core/utils/clusterConfig.ts
+++ b/src/core/utils/clusterConfig.ts
@@ -1,0 +1,35 @@
+import os from 'os'
+
+const MAX_WORKERS = 16
+
+/**
+ * How many HTTP worker processes the cluster should run.
+ *
+ * Set WORKER_COUNT explicitly (e.g. to your container's CPU allocation); the
+ * default is the visible CPU count, capped so a small container on a big host
+ * doesn't oversubscribe. Each worker is its own Node process, so this is what
+ * actually lets the app "use the most it can" across cores instead of being
+ * limited to the single thread of one process.
+ */
+export function getWorkerCount (): number {
+  const parsed = Number.parseInt(process.env.WORKER_COUNT ?? '', 10)
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return Math.min(parsed, MAX_WORKERS)
+  }
+  return Math.min(Math.max(1, os.cpus().length), MAX_WORKERS)
+}
+
+/**
+ * Default per-process MongoDB pool ceiling.
+ *
+ * Every cluster worker (and the primary) owns its own MongoClient, so this
+ * sizes each pool so the TOTAL worst-case connections stay bounded regardless
+ * of cluster size (~1500 across the whole cluster): 1 worker -> 1500, 2 ->
+ * 750 each, 4 -> 375 each, etc. This keeps MongoDB from being hit with
+ * `workers x 1500` connections by accident. An explicit MONGO_MAX_POOL env
+ * override always wins.
+ */
+export function getDefaultMongoPool (): number {
+  const workerCount = getWorkerCount()
+  return Math.max(200, Math.round(1500 / workerCount))
+}

--- a/src/core/utils/clusterConfig.ts
+++ b/src/core/utils/clusterConfig.ts
@@ -22,14 +22,16 @@ export function getWorkerCount (): number {
 /**
  * Default per-process MongoDB pool ceiling.
  *
- * Every cluster worker (and the primary) owns its own MongoClient, so this
- * sizes each pool so the TOTAL worst-case connections stay bounded regardless
- * of cluster size (~1500 across the whole cluster): 1 worker -> 1500, 2 ->
- * 750 each, 4 -> 375 each, etc. This keeps MongoDB from being hit with
- * `workers x 1500` connections by accident. An explicit MONGO_MAX_POOL env
+ * Every cluster worker AND the primary owns its own MongoClient (the primary
+ * connects for bootstrap and cron), so this sizes each pool so the TOTAL
+ * worst-case connections stay bounded regardless of cluster size (~1500 across
+ * the whole cluster): 1 worker -> 750 each (worker + primary), 4 workers ->
+ * 300 each (4 workers + primary), etc. This keeps MongoDB from being hit with
+ * `processes x pool` connections by accident. An explicit MONGO_MAX_POOL env
  * override always wins.
  */
 export function getDefaultMongoPool (): number {
   const workerCount = getWorkerCount()
-  return Math.max(200, Math.round(1500 / workerCount))
+  // +1 includes the primary process, which also connects to MongoDB.
+  return Math.max(200, Math.round(1500 / (workerCount + 1)))
 }

--- a/src/core/utils/telemetry.ts
+++ b/src/core/utils/telemetry.ts
@@ -98,15 +98,31 @@ export function requestEnd (durationMs: number, statusCode: number): void {
     const removed = durations.shift()
     if (removed !== undefined) {
       durationSum -= removed
+      // An evicted sample can no longer define the window's min/max, so
+      // recompute them to keep the reported range reflecting the current
+      // bounded sample buffer instead of evicted values.
+      if (removed === durationMin || removed === durationMax) {
+        durationMin = Number.POSITIVE_INFINITY
+        durationMax = 0
+        for (const sample of durations) {
+          if (sample < durationMin) {
+            durationMin = sample
+          }
+          if (sample > durationMax) {
+            durationMax = sample
+          }
+        }
+      }
     }
   }
 }
 
-/** Record a request rejected by the active-request cap (the 503 backstop). */
+/**
+ * Record a request rejected by the active-request cap (the 503 backstop).
+ * Rejected requests never entered the active gauge (requestStart runs only
+ * for admitted requests), so this only bumps the rejection counters.
+ */
 export function requestRejectedByActiveCap (): void {
-  if (activeRequests > 0) {
-    activeRequests--
-  }
   totalRejected++
   rejectedByActiveCap++
 }

--- a/src/core/utils/telemetry.ts
+++ b/src/core/utils/telemetry.ts
@@ -1,0 +1,245 @@
+import os from 'os'
+import { logger } from 'core/utils/logger'
+
+/**
+ * Lightweight process-wide telemetry for the HTTP request lifecycle and
+ * MongoDB pool health. This exists so production capacity decisions (the
+ * MAX_CONCURRENT_REQUESTS cap, MONGO_MAX_POOL, caching) are driven by real
+ * numbers instead of guesses:
+ *
+ * - Gauges: active/peak requests, uptime, memory, load average.
+ * - Counters: total served, rejected-by-cap, 2xx/3xx/4xx/5xx, Mongo pool
+ *   checkout (wait-queue) timeouts, Mongo server-selection errors.
+ * - A ring buffer of recent request durations so p50/p95/p99 stay cheap and
+ *   bounded (~4k samples, no unbounded growth).
+ *
+ * Exposed two ways:
+ * - GET /metrics (Prometheus text format, wired in RouterServer).
+ * - A periodic console log line (Docker captures it).
+ */
+
+export interface TelemetrySnapshot {
+  uptimeSeconds: number
+  activeRequests: number
+  peakActiveRequests: number
+  totalRequests: number
+  totalRejected: number
+  rejectedByActiveCap: number
+  mongoWaitQueueTimeouts: number
+  mongoServerSelectionErrors: number
+  status2xx: number
+  status3xx: number
+  status4xx: number
+  status5xx: number
+  durationCount: number
+  durationAvgMs: number
+  durationMinMs: number
+  durationMaxMs: number
+  durationP50Ms: number
+  durationP95Ms: number
+  durationP99Ms: number
+}
+
+const DURATION_SAMPLE_LIMIT = 4096
+const startedAt = Date.now()
+
+let activeRequests = 0
+let peakActiveRequests = 0
+let totalRequests = 0
+let totalRejected = 0
+let rejectedByActiveCap = 0
+let mongoWaitQueueTimeouts = 0
+let mongoServerSelectionErrors = 0
+let status2xx = 0
+let status3xx = 0
+let status4xx = 0
+let status5xx = 0
+
+// Bounded ring buffer of recent request durations for percentiles.
+const durations: number[] = []
+let durationSum = 0
+let durationMin = Number.POSITIVE_INFINITY
+let durationMax = 0
+
+/** Record that a dynamic request entered the server (before the cap check). */
+export function requestStart (): void {
+  activeRequests++
+  totalRequests++
+  if (activeRequests > peakActiveRequests) {
+    peakActiveRequests = activeRequests
+  }
+}
+
+/** Record a completed (accepted) request: duration and response status class. */
+export function requestEnd (durationMs: number, statusCode: number): void {
+  if (activeRequests > 0) {
+    activeRequests--
+  }
+
+  if (statusCode < 300) {
+    status2xx++
+  } else if (statusCode < 400) {
+    status3xx++
+  } else if (statusCode < 500) {
+    status4xx++
+  } else {
+    status5xx++
+  }
+
+  durations.push(durationMs)
+  durationSum += durationMs
+  if (durationMs < durationMin) {
+    durationMin = durationMs
+  }
+  if (durationMs > durationMax) {
+    durationMax = durationMs
+  }
+  if (durations.length > DURATION_SAMPLE_LIMIT) {
+    const removed = durations.shift()
+    if (removed !== undefined) {
+      durationSum -= removed
+    }
+  }
+}
+
+/** Record a request rejected by the active-request cap (the 503 backstop). */
+export function requestRejectedByActiveCap (): void {
+  if (activeRequests > 0) {
+    activeRequests--
+  }
+  totalRejected++
+  rejectedByActiveCap++
+}
+
+/** Record a MongoDB driver "timed out checking out a connection" error. */
+export function recordMongoWaitQueueTimeout (): void {
+  mongoWaitQueueTimeouts++
+}
+
+/** Record a MongoDB server-selection timeout. */
+export function recordMongoServerSelectionError (): void {
+  mongoServerSelectionErrors++
+}
+
+function percentile (p: number): number {
+  const count = durations.length
+  if (count === 0) {
+    return 0
+  }
+  const sorted = [...durations].sort((a, b) => a - b)
+  const index = Math.min(count - 1, Math.max(0, Math.ceil((p / 100) * count) - 1))
+  return Math.round(sorted[index] ?? 0)
+}
+
+export function snapshot (): TelemetrySnapshot {
+  const count = durations.length
+  return {
+    uptimeSeconds: Math.floor((Date.now() - startedAt) / 1000),
+    activeRequests,
+    peakActiveRequests,
+    totalRequests,
+    totalRejected,
+    rejectedByActiveCap,
+    mongoWaitQueueTimeouts,
+    mongoServerSelectionErrors,
+    status2xx,
+    status3xx,
+    status4xx,
+    status5xx,
+    durationCount: count,
+    durationAvgMs: count > 0 ? Math.round(durationSum / count) : 0,
+    durationMinMs: Number.isFinite(durationMin) ? Math.round(durationMin) : 0,
+    durationMaxMs: Math.round(durationMax),
+    durationP50Ms: percentile(50),
+    durationP95Ms: percentile(95),
+    durationP99Ms: percentile(99)
+  }
+}
+
+/** Render the snapshot as Prometheus exposition text. */
+export function prometheusText (): string {
+  const s = snapshot()
+  const memory = process.memoryUsage()
+  const load = os.loadavg()
+
+  const lines: string[] = []
+  const emit = (type: string, name: string, help: string, value: number): void => {
+    lines.push(`# HELP ${name} ${help}`)
+    lines.push(`# TYPE ${name} ${type}`)
+    lines.push(`${name} ${value}`)
+  }
+
+  emit('gauge', 'http_active_requests', 'In-flight dynamic HTTP requests in this process', s.activeRequests)
+  emit('gauge', 'http_peak_active_requests', 'Peak concurrent dynamic HTTP requests since boot', s.peakActiveRequests)
+  emit('counter', 'http_requests_total', 'Total dynamic HTTP requests admitted to the server', s.totalRequests)
+  emit('counter', 'http_requests_rejected_total', 'Requests rejected before handling', s.totalRejected)
+  emit('counter', 'http_requests_rejected_active_cap_total', 'Requests rejected by the active-request cap (503)', s.rejectedByActiveCap)
+  emit('counter', 'http_requests_2xx_total', 'Responses with status 200-299', s.status2xx)
+  emit('counter', 'http_requests_3xx_total', 'Responses with status 300-399', s.status3xx)
+  emit('counter', 'http_requests_4xx_total', 'Responses with status 400-499', s.status4xx)
+  emit('counter', 'http_requests_5xx_total', 'Responses with status 500-599', s.status5xx)
+  emit('gauge', 'http_request_duration_avg_ms', 'Average recent request duration in ms', s.durationAvgMs)
+  emit('gauge', 'http_request_duration_min_ms', 'Minimum recent request duration in ms', s.durationMinMs)
+  emit('gauge', 'http_request_duration_max_ms', 'Maximum recent request duration in ms', s.durationMaxMs)
+  emit('gauge', 'http_request_duration_p50_ms', 'Median recent request duration in ms', s.durationP50Ms)
+  emit('gauge', 'http_request_duration_p95_ms', 'p95 recent request duration in ms', s.durationP95Ms)
+  emit('gauge', 'http_request_duration_p99_ms', 'p99 recent request duration in ms', s.durationP99Ms)
+  emit('counter', 'mongo_wait_queue_timeouts_total', 'MongoDB connection checkout (wait-queue) timeouts', s.mongoWaitQueueTimeouts)
+  emit('counter', 'mongo_server_selection_errors_total', 'MongoDB server-selection errors', s.mongoServerSelectionErrors)
+  emit('gauge', 'process_uptime_seconds', 'Seconds since this process started', s.uptimeSeconds)
+  emit('gauge', 'process_rss_bytes', 'Resident set size in bytes', memory.rss)
+  emit('gauge', 'process_heap_used_bytes', 'V8 heap used in bytes', memory.heapUsed)
+  emit('gauge', 'process_heap_total_bytes', 'V8 heap total in bytes', memory.heapTotal)
+  emit('gauge', 'system_loadavg_1m', 'System load average over 1 minute', load[0])
+  emit('gauge', 'system_loadavg_5m', 'System load average over 5 minutes', load[1])
+  emit('gauge', 'system_loadavg_15m', 'System load average over 15 minutes', load[2])
+
+  return `${lines.join('\n')}\n`
+}
+
+/** Log a snapshot line so Docker captures it for capacity planning. */
+export function logSummary (): void {
+  logger.log('info', 'telemetry snapshot', snapshot())
+}
+
+let logInterval: NodeJS.Timeout | null = null
+
+/**
+ * Start a periodic telemetry log. Idempotent; the interval is unref'd so it
+ * never keeps a standalone script or test process alive on its own.
+ */
+export function startPeriodicLogging (intervalMs: number): void {
+  if (logInterval !== null) {
+    return
+  }
+  logInterval = setInterval(() => {
+    logSummary()
+  }, intervalMs)
+  logInterval.unref()
+}
+
+export function stopPeriodicLogging (): void {
+  if (logInterval !== null) {
+    clearInterval(logInterval)
+    logInterval = null
+  }
+}
+
+/** Reset all counters and samples (used by tests). */
+export function reset (): void {
+  activeRequests = 0
+  peakActiveRequests = 0
+  totalRequests = 0
+  totalRejected = 0
+  rejectedByActiveCap = 0
+  mongoWaitQueueTimeouts = 0
+  mongoServerSelectionErrors = 0
+  status2xx = 0
+  status3xx = 0
+  status4xx = 0
+  status5xx = 0
+  durations.length = 0
+  durationSum = 0
+  durationMin = Number.POSITIVE_INFINITY
+  durationMax = 0
+}

--- a/tests/cluster-config.test.ts
+++ b/tests/cluster-config.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { getWorkerCount, getDefaultMongoPool } from '../src/core/utils/clusterConfig'
+
+/**
+ * Run a check with a specific WORKER_COUNT and restore the previous value
+ * afterwards, so the lazily-read env never leaks across tests.
+ */
+function withWorkerCount (value: string | undefined, fn: () => void): void {
+  const previous = process.env.WORKER_COUNT
+  if (value === undefined) {
+    delete process.env.WORKER_COUNT
+  } else {
+    process.env.WORKER_COUNT = value
+  }
+  try {
+    fn()
+  } finally {
+    if (previous === undefined) {
+      delete process.env.WORKER_COUNT
+    } else {
+      process.env.WORKER_COUNT = previous
+    }
+  }
+}
+
+describe('clusterConfig', () => {
+  it('uses WORKER_COUNT when set', () => {
+    withWorkerCount('4', () => {
+      assert.equal(getWorkerCount(), 4)
+    })
+    withWorkerCount('1', () => {
+      assert.equal(getWorkerCount(), 1)
+    })
+  })
+
+  it('clamps WORKER_COUNT to the maximum (16)', () => {
+    withWorkerCount('999', () => {
+      assert.equal(getWorkerCount(), 16)
+    })
+  })
+
+  it('falls back to the CPU count for invalid or non-positive values', () => {
+    withWorkerCount('not-a-number', () => {
+      assert.ok(getWorkerCount() >= 1)
+    })
+    withWorkerCount('0', () => {
+      assert.ok(getWorkerCount() >= 1)
+    })
+    withWorkerCount(undefined, () => {
+      assert.ok(getWorkerCount() >= 1)
+    })
+  })
+
+  it('scales the default Mongo pool per worker to keep the total bounded', () => {
+    withWorkerCount('4', () => {
+      // 1500 / 4 = 375 per worker, so the whole cluster stays ~1500 worst-case.
+      assert.equal(getDefaultMongoPool(), 375)
+    })
+    withWorkerCount('2', () => {
+      assert.equal(getDefaultMongoPool(), 750)
+    })
+    // Never below the 200 floor, even with many workers.
+    withWorkerCount('16', () => {
+      assert.equal(getDefaultMongoPool(), 200)
+    })
+  })
+})

--- a/tests/cluster-config.test.ts
+++ b/tests/cluster-config.test.ts
@@ -52,13 +52,15 @@ describe('clusterConfig', () => {
     })
   })
 
-  it('scales the default Mongo pool per worker to keep the total bounded', () => {
+  it('scales the default Mongo pool per process to keep the total bounded', () => {
     withWorkerCount('4', () => {
-      // 1500 / 4 = 375 per worker, so the whole cluster stays ~1500 worst-case.
-      assert.equal(getDefaultMongoPool(), 375)
+      // 1500 / (4 workers + 1 primary) = 300 per process, so the whole cluster
+      // (workers + primary) stays ~1500 worst-case.
+      assert.equal(getDefaultMongoPool(), 300)
     })
     withWorkerCount('2', () => {
-      assert.equal(getDefaultMongoPool(), 750)
+      // 1500 / (2 workers + 1 primary) = 500 per process.
+      assert.equal(getDefaultMongoPool(), 500)
     })
     // Never below the 200 floor, even with many workers.
     withWorkerCount('16', () => {

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -1,0 +1,81 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  snapshot,
+  requestStart,
+  requestEnd,
+  requestRejectedByActiveCap,
+  recordMongoWaitQueueTimeout,
+  recordMongoServerSelectionError,
+  prometheusText,
+  reset
+} from '../src/core/utils/telemetry'
+
+describe('telemetry', () => {
+  it('tracks active and peak requests across start/end', () => {
+    reset()
+    requestStart()
+    requestStart()
+    assert.equal(snapshot().activeRequests, 2)
+    assert.equal(snapshot().peakActiveRequests, 2)
+    assert.equal(snapshot().totalRequests, 2)
+
+    requestEnd(10, 200)
+    assert.equal(snapshot().activeRequests, 1)
+    assert.equal(snapshot().peakActiveRequests, 2)
+    assert.equal(snapshot().status2xx, 1)
+
+    requestEnd(20, 404)
+    assert.equal(snapshot().activeRequests, 0)
+    assert.equal(snapshot().status4xx, 1)
+  })
+
+  it('records a cap rejection without leaking the active count', () => {
+    reset()
+    requestStart()
+    requestStart()
+    requestRejectedByActiveCap()
+    assert.equal(snapshot().activeRequests, 1)
+    assert.equal(snapshot().totalRejected, 1)
+    assert.equal(snapshot().rejectedByActiveCap, 1)
+  })
+
+  it('computes duration percentiles and average', () => {
+    reset()
+    // Ten samples of 1..10 ms.
+    for (let i = 1; i <= 10; i++) {
+      requestStart()
+      requestEnd(i, 200)
+    }
+    const s = snapshot()
+    assert.equal(s.durationCount, 10)
+    assert.equal(s.durationMinMs, 1)
+    assert.equal(s.durationMaxMs, 10)
+    assert.equal(s.durationAvgMs, Math.round(55 / 10))
+    assert.ok(s.durationP50Ms >= 5 && s.durationP50Ms <= 6)
+    assert.equal(s.durationP95Ms, 10)
+    assert.equal(s.durationP99Ms, 10)
+  })
+
+  it('counts MongoDB pool health errors separately', () => {
+    reset()
+    recordMongoWaitQueueTimeout()
+    recordMongoWaitQueueTimeout()
+    recordMongoServerSelectionError()
+    const s = snapshot()
+    assert.equal(s.mongoWaitQueueTimeouts, 2)
+    assert.equal(s.mongoServerSelectionErrors, 1)
+  })
+
+  it('renders Prometheus text with expected metric names', () => {
+    reset()
+    requestStart()
+    requestEnd(5, 200)
+    const text = prometheusText()
+    assert.match(text, /# TYPE http_active_requests gauge/)
+    assert.match(text, /# TYPE http_requests_total counter/)
+    assert.match(text, /http_requests_total 1/)
+    assert.match(text, /http_request_duration_p95_ms 5/)
+    assert.match(text, /mongo_wait_queue_timeouts_total 0/)
+  })
+})

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -30,12 +30,14 @@ describe('telemetry', () => {
     assert.equal(snapshot().status4xx, 1)
   })
 
-  it('records a cap rejection without leaking the active count', () => {
+  it('records a cap rejection without touching the active count', () => {
     reset()
     requestStart()
     requestStart()
+    assert.equal(snapshot().activeRequests, 2)
     requestRejectedByActiveCap()
-    assert.equal(snapshot().activeRequests, 1)
+    // A rejected request never entered the active gauge, so it must stay put.
+    assert.equal(snapshot().activeRequests, 2)
     assert.equal(snapshot().totalRejected, 1)
     assert.equal(snapshot().rejectedByActiveCap, 1)
   })
@@ -55,6 +57,25 @@ describe('telemetry', () => {
     assert.ok(s.durationP50Ms >= 5 && s.durationP50Ms <= 6)
     assert.equal(s.durationP95Ms, 10)
     assert.equal(s.durationP99Ms, 10)
+  })
+
+  it('recomputes min/max when an evicted sample defined them', () => {
+    reset()
+    // Fill the bounded ring buffer (DURATION_SAMPLE_LIMIT = 4096) with one
+    // value, then push values whose insertion evicts the original min/max so
+    // they must be recomputed from the remaining window.
+    for (let i = 0; i < 4096; i++) {
+      requestStart()
+      requestEnd(5, 200)
+    }
+    requestStart()
+    requestEnd(1, 200) // evicts a 5 -> min becomes 1
+    requestStart()
+    requestEnd(100, 200) // evicts a 5 -> max becomes 100
+    const s = snapshot()
+    assert.equal(s.durationCount, 4096)
+    assert.equal(s.durationMinMs, 1)
+    assert.equal(s.durationMaxMs, 100)
   })
 
   it('counts MongoDB pool health errors separately', () => {


### PR DESCRIPTION
Fix production "Server is busy, please try again shortly" (HTTP 503) errors that occur at ~120M requests/month. The 503s come from the `MAX_CONCURRENT_REQUESTS` HTTP cap being saturated (Node is single-threaded per process), not from the MongoDB pool. This MR scales the app and removes the guesswork:

1. **Telemetry** — new `GET /metrics` (Prometheus text) + periodic logs tracking active/peak requests, 503 rejections, latency p50/p95/p99, and MongoDB pool timeouts separately, so capacity decisions are data-driven.
2. **Reduced Mongo fan-out** — the busiest route (search) drops from ~6 concurrent Mongo operations to ~2 by consolidating results+count and the four facet queries into single `$facet` aggregations, relieving pool pressure and lowering latency.
3. **Node cluster mode** — the app now forks `WORKER_COUNT` HTTP workers across all CPU cores, with one-time migrations/indexes/sitemap and single-run cron jobs in the primary process, auto-healing workers, graceful shutdown, and per-worker Mongo pool auto-scaling (total worst-case connections stay bounded).


### Checklist
- [x] The changes are scoped appropriately
- [x] The project builds and runs successfully
- [x] I have self reviewed the changes