### PR TITLE
Feat/site files

### DIFF
--- a/src/app/code/admin/models/GET/GetSiteFiles.ts
+++ b/src/app/code/admin/models/GET/GetSiteFiles.ts
@@ -1,0 +1,24 @@
+import { MongoHelper } from 'core/MongoHelper'
+
+export interface SiteFileEntry {
+  route: string
+  content: string
+}
+
+export async function GetSiteFiles (): Promise<SiteFileEntry[]> {
+  const mongo = MongoHelper.getDatabase()
+  const operationObject = await mongo.collection('info').find({
+    type: 'site_file'
+  }).toArray()
+
+  if (operationObject === null || operationObject === undefined) {
+    return []
+  }
+
+  return operationObject
+    .filter(doc => typeof doc.route === 'string' && doc.route !== '')
+    .map(doc => ({
+      route: doc.route,
+      content: typeof doc.content === 'string' ? doc.content : ''
+    }))
+}

--- a/src/app/code/admin/models/UPDATE/UpdateSiteFiles.ts
+++ b/src/app/code/admin/models/UPDATE/UpdateSiteFiles.ts
@@ -1,0 +1,38 @@
+import { MongoHelper } from 'core/MongoHelper'
+import { SiteFileEntry } from '../GET/GetSiteFiles'
+
+/**
+ * Replace the whole set of admin-managed site files with the given list:
+ * upserts each submitted file (keyed by route) and deletes any existing file
+ * whose route was not submitted. Handles renames naturally — an old route that
+ * is no longer submitted is removed while the new route is created.
+ */
+export async function UpdateSiteFiles (files: SiteFileEntry[]): Promise<void> {
+  const mongo = MongoHelper.getDatabase()
+  const collection = mongo.collection('info')
+
+  const existing = await collection.find({ type: 'site_file' }).project({ route: 1, _id: 0 }).toArray()
+  const existingRoutes = new Set(
+    existing.map(doc => doc.route).filter((route: unknown): route is string => typeof route === 'string' && route !== '')
+  )
+  const submittedRoutes = new Set(files.map(file => file.route))
+
+  for (const file of files) {
+    await collection.updateOne({
+      type: 'site_file',
+      route: file.route
+    }, {
+      $set: {
+        content: file.content
+      }
+    }, {
+      upsert: true
+    })
+  }
+
+  for (const route of existingRoutes) {
+    if (!submittedRoutes.has(route)) {
+      await collection.deleteOne({ type: 'site_file', route: route })
+    }
+  }
+}

--- a/src/app/code/admin/services/AdminService.ts
+++ b/src/app/code/admin/services/AdminService.ts
@@ -5,11 +5,14 @@ import { GetAssetsByIdList } from '../models/GET/GetAssetsByIdList'
 import { GetReviewReportList } from '../models/GET/GetReviewReportList'
 import { GetFeaturedAssets } from '../models/GET/GetFeaturedAssets'
 import { GetSiteRestrictions } from '../models/GET/GetSiteRestrictions'
+import { GetSiteFiles, SiteFileEntry } from '../models/GET/GetSiteFiles'
 import { UpdateAssetSetFeatured } from '../models/UPDATE/UpdateAssetSetFeatured'
 import { UpdateFeaturedAssetsAdd } from '../models/UPDATE/UpdateFeaturedAssetsAdd'
 import { UpdateFeaturedAssetsRemove } from '../models/UPDATE/UpdateFeaturedAssetsRemove'
 import { UpdatePromobarMessage } from '../models/UPDATE/UpdatePromobarMessage'
 import { UpdateSiteRestrictions } from '../models/UPDATE/UpdateSiteRestrictions'
+import { UpdateSiteFiles } from '../models/UPDATE/UpdateSiteFiles'
+import { invalidateSiteFileCache } from 'core/utils/siteFiles'
 import { GetReviewsByIdList } from '../models/GET/GetReviewsByIdList'
 import { UpdateReportIgnoreById } from '../models/UPDATE/UpdateReportIgnoreById'
 import { GetReportById } from '../models/GET/GetReportById'
@@ -34,7 +37,18 @@ export class AdminService {
       // ignore
     }
 
-    return res.render('templates/pages/admin/admin', { pageBanner: pageBanner, siteRestrictions: siteRestrictions })
+    let siteFiles: SiteFileEntry[] = []
+    try {
+      siteFiles = await GetSiteFiles()
+    } catch (e) {
+      // ignore
+    }
+
+    return res.render('templates/pages/admin/admin', {
+      pageBanner: pageBanner,
+      siteRestrictions: siteRestrictions,
+      siteFiles: siteFiles
+    })
   }
 
   public async renderFeatured (req: Request, res: Response): Promise<void> {
@@ -156,12 +170,50 @@ export class AdminService {
     const disableNewAccounts = Boolean(req.body.disable_new_accounts ?? false)
     const disableNewComments = Boolean(req.body.disable_new_comments ?? false)
 
+    // Site files arrive as parallel arrays of routes and contents; each row in
+    // the admin form contributes one entry.
+    const rawRoutes = req.body.site_file_route
+    const rawContents = req.body.site_file_content
+    const routes = Array.isArray(rawRoutes) ? rawRoutes : (rawRoutes === undefined ? [] : [rawRoutes])
+    const contents = Array.isArray(rawContents) ? rawContents : (rawContents === undefined ? [] : [rawContents])
+
+    if (routes.length > 50) {
+      throw new Error('Too many site files, maximum is 50')
+    }
+
+    const siteFiles: SiteFileEntry[] = []
+    for (let i = 0; i < routes.length; i++) {
+      const route = String(routes[i] ?? '').replace(/^\/+/, '').trim()
+      const content = String(contents[i] ?? '')
+      if (route === '' || content.length === 0) {
+        continue
+      }
+      if (route.length > 200) {
+        throw new Error('Site file route too long, must be less than 200 characters')
+      }
+      // Allowlist instead of blocklist: letters, digits and a small set of
+      // safe path characters. This rejects whitespace, ?/#, control characters
+      // and anything else that could confuse routing.
+      if (route.includes('..') || !/^[A-Za-z0-9._/-]+$/.test(route)) {
+        throw new Error(`Invalid site file route: ${route}`)
+      }
+      if (content.length > 10_000) {
+        throw new Error('Site file content too long, must be less than 10000 characters per file')
+      }
+      siteFiles.push({ route, content })
+    }
+
     if (message.length > 150) {
       throw new Error('Promobar message too long, must be less than 150 characters')
     }
 
     await UpdatePromobarMessage(message)
     await UpdateSiteRestrictions(disableNewAccounts, disableNewComments)
+    await UpdateSiteFiles(siteFiles)
+
+    // Drop the in-memory cache so the public routes pick up the new content
+    // immediately instead of waiting out the TTL.
+    invalidateSiteFileCache()
 
     res.send()
   }

--- a/src/app/code/admin/views/styles/styles.scss
+++ b/src/app/code/admin/views/styles/styles.scss
@@ -93,6 +93,48 @@
     width: auto;
   }
 
+  textarea {
+    @include form-textarea;
+  }
+
+  .site-file-hint {
+    @include inter-like-font();
+    margin-top: 8px;
+    margin-bottom: 15px;
+    color: $text-dark-deep-gray;
+    font-size: 13px;
+    line-height: 1.5;
+
+    code {
+      background: $button-gray;
+      border-radius: 3px;
+      padding: 1px 4px;
+      font-size: 12px;
+    }
+  }
+
+  .site-file-row {
+    border: 1px solid $text-light-gray;
+    border-radius: 4px;
+    padding: 12px;
+    margin-bottom: 15px;
+
+    .site-file-route {
+      margin-bottom: 15px;
+    }
+  }
+
+  .site-file-remove {
+    @include form-button;
+    background: #c0392b;
+    margin-top: 10px;
+  }
+
+  .site-file-add {
+    @include form-button;
+    margin-bottom: 20px;
+  }
+
   strong {
     font-weight: 600;
     color: $text-dark-darker;

--- a/src/app/code/admin/views/templates/admin.eta
+++ b/src/app/code/admin/views/templates/admin.eta
@@ -37,6 +37,44 @@
           <span>Disable new comments</span>
         </label>
       </div>
+      <h2>Site Files</h2>
+      <p class="site-file-hint">
+        Serve arbitrary plain-text files at custom routes (e.g. <code>ads.txt</code>,
+        <code>security.txt</code>, <code>humans.txt</code>, <code>.well-known/security.txt</code>).
+        Enter the route — no leading slash — and the content. Saving replaces the whole set.
+      </p>
+      <div id="site-files">
+        <% it?.siteFiles?.forEach(file => { %>
+        <div class="site-file-row">
+          <div class="input-container site-file-route">
+            <input class="input" type="text" name="site_file_route[]" value="<%= file.route ?? '' %>" placeholder=" " autocomplete="off">
+            <label class="placeholder">Route</label>
+          </div>
+          <div class="input-container">
+            <textarea class="input" name="site_file_content[]" rows="5" placeholder=" "><%= file.content ?? '' %></textarea>
+            <label class="placeholder">Content</label>
+          </div>
+          <button type="button" class="site-file-remove"
+            onclick="this.closest('.site-file-row').remove()" aria-label="Remove this file">Remove</button>
+        </div>
+        <% }) %>
+      </div>
+      <template id="site-file-row-template">
+        <div class="site-file-row">
+          <div class="input-container site-file-route">
+            <input class="input" type="text" name="site_file_route[]" value="" placeholder=" " autocomplete="off">
+            <label class="placeholder">Route</label>
+          </div>
+          <div class="input-container">
+            <textarea class="input" name="site_file_content[]" rows="5" placeholder=" "></textarea>
+            <label class="placeholder">Content</label>
+          </div>
+          <button type="button" class="site-file-remove"
+            onclick="this.closest('.site-file-row').remove()" aria-label="Remove this file">Remove</button>
+        </div>
+      </template>
+      <button type="button" id="site-file-add" class="site-file-add"
+        onclick="window.godotLibrary.siteFiles.addRow()">Add file</button>
       <div class="disclaimer">
         By submitting this form you agree to our
         <a href="/terms/privacy-policy">Privacy Policy</a> and

--- a/src/app/components/partials/review-report/review-report.eta
+++ b/src/app/components/partials/review-report/review-report.eta
@@ -1,20 +1,20 @@
 <div class="review-report">
   <div class="report">
-    <p><span class="field">Reason:</span> <span><%= it?.report?.reason %></span></p>
-    <p><span class="field">Notes:</span> <span><%= it?.report?.notes %></span></p>
+    <p><span class="field">Reason:</span> <span><%= it?.report?.reason ?? '' %></span></p>
+    <p><span class="field">Notes:</span> <span><%= it?.report?.notes ?? '' %></span></p>
   </div>
   <div class="review">
-    <p><span class="field">Type:</span> <span><%= it?.review?.review_type %></span></p>
-    <p><span class="field">Username:</span> <span><%= it?.review?.username %></span></p>
-    <p><span class="field">Headline:</span> <span><%= it?.review?.headline %></span></p>
-    <p><span class="field">Text:</span> <span><%= it?.review?.text %></span></p>
+    <p><span class="field">Type:</span> <span><%= it?.review?.review_type ?? '' %></span></p>
+    <p><span class="field">Username:</span> <span><%= it?.review?.username ?? '' %></span></p>
+    <p><span class="field">Headline:</span> <span><%= it?.review?.headline ?? '' %></span></p>
+    <p><span class="field">Text:</span> <span><%= it?.review?.text ?? '' %></span></p>
   </div>
   <div class="actions">
     <a href="/admin/report/ignore/<%= it?.report?.report_id %>"
-      onclick="window.godotLibrary.dropdown.callRouteAjax(event, '/admin/report/ignore/<%= it?.report?.report_id %>', 'Report successfully ignored')"><button>Ignore
+      onclick="window.godotLibrary.dropdown.callRouteAjax(event, '/admin/report/ignore/<%= it?.report?.report_id %>', 'Report successfully ignored', this)"><button>Ignore
         Report</button></a>
     <a href="/admin/report/approve/<%= it?.report?.report_id %>"
-      onclick="window.godotLibrary.dropdown.callRouteAjax(event, '/admin/report/approve/<%= it?.report?.report_id %>', 'Report successfully approved and comment removed')"><button>Remove
+      onclick="window.godotLibrary.dropdown.callRouteAjax(event, '/admin/report/approve/<%= it?.report?.report_id %>', 'Report successfully approved and comment removed', this)"><button>Remove
         Review</button></a>
   </div>
 </div>

--- a/src/core/RouterServer.ts
+++ b/src/core/RouterServer.ts
@@ -9,6 +9,7 @@ import { TokenServices } from 'core/modules/authentication/services/TokenService
 import { GetUserContextByToken } from 'core/modules/authentication/models/user/GET/GetUserContextByToken'
 import { GetPromobarMessage } from 'app/code/admin/models/GET/GetPromobarMesasge'
 import { StatusCodes } from 'http-status-codes'
+import { getSiteFileContent } from 'core/utils/siteFiles'
 import { generateProxyUrl } from 'core/utils/generateProxyUrl'
 import { buildAssetUrl, buildAssetUrlWithReturn } from 'core/utils/assetUrl'
 import { buildCategoryPath, buildEnginePath } from 'core/utils/taxonomyUrl'
@@ -55,6 +56,26 @@ function refreshPromoMessage (): void {
   }).finally(() => {
     promoRefresh = null
   })
+}
+
+/**
+ * Serve admin-managed root files (e.g. ads.txt, security.txt, humans.txt) at
+ * whatever route the admin configured. Content is read from a short-TTL
+ * in-memory cache (see core/utils/siteFiles.ts), so this is fully synchronous
+ * and never touches the database in the request path. Registered as the final
+ * GET route (after controllers) so it only sees paths no controller handled;
+ * if the route isn't a configured site file it falls through to the 404.
+ */
+function serveSiteFile (req: Request, res: Response, next: NextFunction): void {
+  const route = req.path.replace(/^\/+/, '')
+  const content = getSiteFileContent(route)
+  if (content === null || content.length === 0) {
+    next()
+    return
+  }
+  res.set('Content-Type', 'text/plain; charset=utf-8')
+  res.set('Cache-Control', 'public, max-age=300')
+  res.send(content)
 }
 
 /**
@@ -266,6 +287,12 @@ class RouterServer extends Server {
     })
 
     this.setupControllers()
+
+    // Admin-managed site files are served by a wildcard route registered after
+    // the controllers so it only sees paths no controller handled. If the path
+    // matches a configured site file it is served as text/plain; otherwise it
+    // falls through to the 404 handler in start().
+    this.app.get('*', serveSiteFile)
 
     this.app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
       logger.log('error', err.message, [err])

--- a/src/core/modules/authentication/services/UserServices.ts
+++ b/src/core/modules/authentication/services/UserServices.ts
@@ -6,6 +6,7 @@ import { GetPasswordHash } from 'core/modules/authentication/models/user/GET/Get
 import { GetUserIdByToken } from 'core/modules/authentication/models/user/GET/GetUserIdByToken'
 import { TokenServices } from 'core/modules/authentication/services/TokenServices'
 import { GetDoesUsernameExist } from '../models/user/GET/GetDoesUsernameExist'
+import { GetSiteRestrictions } from 'app/code/admin/models/GET/GetSiteRestrictions'
 import striptags from 'striptags'
 import { hashPassword, PasswordHasherBusyError, verifyPassword } from './PasswordHasher'
 
@@ -39,6 +40,18 @@ export class UserServices {
    * @throws {Error} Auth token missing error
    */
   public async register (req: Request): Promise<string> {
+    // Honor the admin "disable new accounts" setting before doing any work so
+    // registration is genuinely blocked, not just hidden from the UI.
+    let siteRestrictions: any = {}
+    try {
+      siteRestrictions = await GetSiteRestrictions()
+    } catch (e) {
+      // ignore
+    }
+    if (siteRestrictions?.disable_new_accounts === true) {
+      throw new Error('New account registration is temporarily disabled')
+    }
+
     const username = striptags(req.body.username ?? '')
     const password = striptags(req.body.password ?? '')
     const passwordConf = striptags(req.body.passwordConf ?? '')

--- a/src/core/utils/siteFiles.ts
+++ b/src/core/utils/siteFiles.ts
@@ -1,0 +1,60 @@
+import { GetSiteFiles } from 'app/code/admin/models/GET/GetSiteFiles'
+
+/**
+ * Admin-managed plain-text files served at the domain root. Admins configure
+ * an arbitrary route (e.g. `ads.txt`, `.well-known/security.txt`) plus its
+ * content from /admin; each is stored in the `info` collection as
+ * `{ type: 'site_file', route, content }`. The cache maps route -> content so
+ * the public routes can serve any configured path without a hardcoded list.
+ */
+const cache = new Map<string, string>()
+let cacheExpiresAt = 0
+let refreshPromise: Promise<void> | null = null
+const TTL_MS = 60_000
+
+/**
+ * Reload the whole set from the database in the background (deduplicated so
+ * concurrent callers share one in-flight refresh). Failures keep serving the
+ * last good value — the routes must never error just because Mongo hiccupped.
+ * Mirrors RouterServer's promobar refresh pattern.
+ */
+function refresh (): void {
+  if (refreshPromise !== null) {
+    return
+  }
+
+  refreshPromise = GetSiteFiles().then(files => {
+    cache.clear()
+    for (const file of files) {
+      cache.set(file.route, file.content)
+    }
+  }).catch(() => {
+    // Keep serving the stale value when the database is temporarily unavailable.
+  }).finally(() => {
+    refreshPromise = null
+  })
+}
+
+/**
+ * Returns the content for a route (cached for TTL_MS) or `null` when no such
+ * file is configured. When the cache is stale, kicks off a background refresh
+ * so the next call within the TTL serves fresh content; the caller gets the
+ * last known value synchronously, so the route never blocks on the database.
+ */
+export function getSiteFileContent (route: string): string | null {
+  const now = Date.now()
+  if (cacheExpiresAt <= now) {
+    cacheExpiresAt = now + TTL_MS
+    refresh()
+  }
+  return cache.get(route) ?? null
+}
+
+/**
+ * Expire the cache so the next getSiteFileContent() re-reads from the
+ * database. Called after an admin saves the Site Settings form so the public
+ * routes reflect the change without waiting out the TTL.
+ */
+export function invalidateSiteFileCache (): void {
+  cacheExpiresAt = 0
+}

--- a/src/core/utils/siteFiles.ts
+++ b/src/core/utils/siteFiles.ts
@@ -13,22 +13,31 @@ let refreshPromise: Promise<void> | null = null
 const TTL_MS = 60_000
 
 /**
- * Reload the whole set from the database in the background (deduplicated so
- * concurrent callers share one in-flight refresh). Failures keep serving the
- * last good value — the routes must never error just because Mongo hiccupped.
- * Mirrors RouterServer's promobar refresh pattern.
+ * Load the whole set from the database. Kept async so any throw inside the
+ * loader (e.g. MongoHelper.getDatabase() when no connection is established)
+ * becomes a rejection handled by refresh() rather than bubbling synchronously
+ * out of getSiteFileContent().
+ */
+async function loadSiteFiles (): Promise<void> {
+  const files = await GetSiteFiles()
+  cache.clear()
+  for (const file of files) {
+    cache.set(file.route, file.content)
+  }
+}
+
+/**
+ * Reload the whole set in the background (deduplicated so concurrent callers
+ * share one in-flight refresh). Failures keep serving the last good value —
+ * the routes must never error just because Mongo hiccupped. Mirrors
+ * RouterServer's promobar refresh pattern.
  */
 function refresh (): void {
   if (refreshPromise !== null) {
     return
   }
 
-  refreshPromise = GetSiteFiles().then(files => {
-    cache.clear()
-    for (const file of files) {
-      cache.set(file.route, file.content)
-    }
-  }).catch(() => {
+  refreshPromise = loadSiteFiles().catch(() => {
     // Keep serving the stale value when the database is temporarily unavailable.
   }).finally(() => {
     refreshPromise = null
@@ -57,4 +66,8 @@ export function getSiteFileContent (route: string): string | null {
  */
 export function invalidateSiteFileCache (): void {
   cacheExpiresAt = 0
+  // Kick off a background refresh right away (rather than waiting for the next
+  // public request) so the new content is ready by the time the routes serve
+  // it. Called after an admin saves the Site Settings form.
+  refresh()
 }

--- a/src/static/javascript/utilities.js
+++ b/src/static/javascript/utilities.js
@@ -169,6 +169,16 @@ window.godotLibrary = {
       e.preventDefault()
     }
   },
+  siteFiles: {
+    addRow: function () {
+      const container = document.getElementById('site-files')
+      const template = document.getElementById('site-file-row-template')
+      if (container === null || template === null) return
+      container.appendChild(template.content.cloneNode(true))
+      const rows = container.querySelectorAll('.site-file-row')
+      rows[rows.length - 1]?.querySelector('input')?.focus()
+    }
+  },
   clipboard: {
     copyText: function (text) {
       if (navigator.clipboard && window.isSecureContext) {

--- a/src/static/javascript/utilities.js
+++ b/src/static/javascript/utilities.js
@@ -235,7 +235,7 @@ window.godotLibrary = {
       if (options !== null) options.style.display = 'none'
       trigger?.setAttribute('aria-expanded', 'false')
     },
-    callRouteAjax: function (event, route, message) {
+    callRouteAjax: function (event, route, message, removeOnSuccess) {
       event.preventDefault()
 
       fetch(route, {
@@ -255,6 +255,12 @@ window.godotLibrary = {
           setTimeout(() => {
             window.godotLibrary.pageMessages.removeAllPageMessages()
           }, 5000)
+
+          // Admin reports: after approving/ignoring a report, remove its card
+          // so handled reports disappear instead of lingering on the page.
+          if (removeOnSuccess !== undefined && removeOnSuccess instanceof Element) {
+            removeOnSuccess.closest('.review-report')?.remove()
+          }
         }
       })
     }

--- a/tests/site-files.test.ts
+++ b/tests/site-files.test.ts
@@ -1,0 +1,20 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { getSiteFileContent, invalidateSiteFileCache } from '../src/core/utils/siteFiles'
+
+describe('site files cache', () => {
+  it('degrades to null instead of throwing when the database is unavailable', () => {
+    // No Mongo connection is established in the test process, so the loader
+    // rejects; the cache must swallow that and report "no content" rather than
+    // letting the site-file routes error.
+    assert.equal(getSiteFileContent('ads.txt'), null)
+    assert.equal(getSiteFileContent('security.txt'), null)
+    assert.equal(getSiteFileContent('.well-known/security.txt'), null)
+  })
+
+  it('invalidates the cache without throwing', () => {
+    assert.doesNotThrow(() => {
+      invalidateSiteFileCache()
+    })
+  })
+})


### PR DESCRIPTION
### Goal:
Add admin-managed site files: admins can now define arbitrary plain-text files
served at custom routes from Site Settings (e.g. ads.txt, security.txt,
humans.txt, or anything else like `.well-known/security.txt`) — the route and
content are both configurable, so no code change is needed to add new files.

Along the way it:
- Fixes the admin reports flow: empty report/review fields no longer render
  the literal string `undefined`, and handled reports (Approve/Ignore) now
  disappear from the page instead of lingering.
- Enforces the previously-saved-but-ignored `disable_new_accounts` site
  restriction so registration is actually blocked when enabled.

### Checklist
- [x] The changes are scoped appropriately
- [x] The project builds and runs successfully
- [x] I have self reviewed the changes