### PR TITLE
Feat/dragonfly cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,13 @@ IMGPROXY_HOST=https://img.godotassetlibrary.com
 IMGPROXY_ENABLED=true
 PROJECT_BASE_URL=https://godotassetlibrary.com
 
+# Shared cache (Dragonfly speaks the Redis protocol). Production Compose sets
+# DRAGONFLY_URL automatically; set CACHE_ENABLED=false for an emergency bypass.
+# DRAGONFLY_URL=redis://dragonfly:6379
+# CACHE_ENABLED=true
+# CACHE_HOMEPAGE_TTL_SECONDS=60
+# CACHE_SEARCH_TTL_SECONDS=60
+
 # --- Cluster / concurrency / pooling tuning (optional) ---
 # Node cluster mode: the app forks WORKER_COUNT HTTP worker processes (each is
 # its own Node process using a CPU core), plus a primary that runs migrations,

--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,7 @@ PROJECT_BASE_URL=https://godotassetlibrary.com
 # CACHE_HOMEPAGE_TTL_SECONDS=60
 # CACHE_SEARCH_TTL_SECONDS=60
 # CACHE_ASSET_TTL_SECONDS=30        # asset detail page (reviews + rating; invalidated on review/admin writes)
+# CACHE_USER_CTX_TTL_SECONDS=30     # authenticated login context (invalidated on logout/account delete)
 
 # --- Cluster / concurrency / pooling tuning (optional) ---
 # Node cluster mode: the app forks WORKER_COUNT HTTP worker processes (each is
@@ -45,7 +46,6 @@ PROJECT_BASE_URL=https://godotassetlibrary.com
 # MONGO_MAX_POOL=1500        # explicit per-process max connections (overrides the cluster auto-scale)
 # MONGO_MIN_POOL=0           # pre-warmed connections kept ready (default 0 = none; pure lazy)
 # MONGO_MAX_IDLE_MS=300000   # close idle connections after this many ms (default 5 min)
-# MAX_CONCURRENT_REQUESTS=500  # in-flight dynamic HTTP requests cap per worker (default 500; last-resort 503 backstop)
 # TELEMETRY_LOG_INTERVAL_MS=60000  # how often to log a telemetry snapshot (ms; default 60s)
 # METRICS_TOKEN=             # optional bearer token protecting GET /metrics (leave blank to keep it open)
 # ARGON2_MAX_CONCURRENCY=2

--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,7 @@ PROJECT_BASE_URL=https://godotassetlibrary.com
 # CACHE_ENABLED=true
 # CACHE_HOMEPAGE_TTL_SECONDS=60
 # CACHE_SEARCH_TTL_SECONDS=60
+# CACHE_ASSET_TTL_SECONDS=30        # asset detail page (reviews + rating; invalidated on review/admin writes)
 
 # --- Cluster / concurrency / pooling tuning (optional) ---
 # Node cluster mode: the app forks WORKER_COUNT HTTP worker processes (each is

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ RUN apk add --no-cache python3 make g++ \
 COPY . .
 RUN npm run build
 
+# Express enables its compiled view cache in production. Set this only after
+# the build so npm ci still installs TypeScript/Webpack dev dependencies.
+ENV NODE_ENV=production
+
 EXPOSE 3000
 
 CMD ["node", "dist/bundle.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     restart: always
     env_file: .env
     environment:
+      - NODE_ENV=production
       - DB_USERNAME=$DB_USERNAME
       - DB_PASSWORD=$DB_PASSWORD
       - DB_HOST=db
@@ -17,6 +18,12 @@ services:
       - SMTP_PORT=$SMTP_PORT
       - SMTP_USER=$SMTP_USER
       - SMTP_PASS=$SMTP_PASS
+      - DRAGONFLY_URL=redis://dragonfly:6379
+    depends_on:
+      db:
+        condition: service_started
+      dragonfly:
+        condition: service_healthy
     ports:
       - "8080:3000"
     networks:
@@ -27,6 +34,27 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+
+  dragonfly:
+    image: docker.dragonflydb.io/dragonflydb/dragonfly:v1.35.1
+    container_name: gda_dragonfly
+    restart: unless-stopped
+    command:
+      - --cache_mode=true
+      - --maxmemory=512mb
+      - --proactor_threads=1
+      - --primary_port_http_enabled=false
+      - --version_check=false
+    ulimits:
+      memlock: -1
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
 
   db:
     image: mongo:5.0.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "nodemailer": "^6.7.2",
         "nodemon": "^2.0.15",
         "pubsub-js": "^1.9.4",
+        "redis": "^4.7.0",
         "request": "^2.88.2",
         "sass": "^1.49.7",
         "sitemap": "^7.1.1",
@@ -58,7 +59,6 @@
       "devDependencies": {
         "@overnightjs/core": "^1.7.6",
         "@types/adm-zip": "^0.5.0",
-        "@types/apicache": "^1.6.1",
         "@types/compression": "^1.7.2",
         "@types/cookie-parser": "^1.4.2",
         "@types/create-hmac": "^1.1.0",
@@ -714,6 +714,65 @@
         "node": ">=10"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.0.tgz",
+      "integrity": "sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@smithy/core": {
       "version": "3.31.1",
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
@@ -836,15 +895,6 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/apicache": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@types/apicache/-/apicache-1.6.1.tgz",
-      "integrity": "sha512-vNUh8lponMjIOPGVp04xf9avb5lJTR6qSW3IS3ROmugMFLvNXwI3nPC1JnnoA6zyEC7HHqW0LGfuLSue32C9dQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/redis": "^2.8.0"
       }
     },
     "node_modules/@types/body-parser": {
@@ -1065,15 +1115,6 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
-    },
-    "node_modules/@types/redis": {
-      "version": "2.8.32",
-      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.32.tgz",
-      "integrity": "sha512-7jkMKxcGq9p242exlbsVzuJb57KqHRhNl4dHoQu2Y5v9bCAbtIXXH0R3HleSQW4CTOqpHIYUW3t6tpUj4BVQ+w==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/sax": {
       "version": "1.2.4",
@@ -2085,6 +2126,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/color": {
@@ -3779,6 +3829,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/get-caller-file": {
@@ -6082,6 +6141,23 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.0.tgz",
+      "integrity": "sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.0",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
       }
     },
     "node_modules/reflect-metadata": {
@@ -8715,6 +8791,46 @@
       "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
       "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ=="
     },
+    "@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "requires": {}
+    },
+    "@redis/client": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.0.tgz",
+      "integrity": "sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==",
+      "requires": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      }
+    },
+    "@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "requires": {}
+    },
+    "@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "requires": {}
+    },
+    "@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "requires": {}
+    },
+    "@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "requires": {}
+    },
     "@smithy/core": {
       "version": "3.31.1",
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
@@ -8810,15 +8926,6 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/apicache": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@types/apicache/-/apicache-1.6.1.tgz",
-      "integrity": "sha512-vNUh8lponMjIOPGVp04xf9avb5lJTR6qSW3IS3ROmugMFLvNXwI3nPC1JnnoA6zyEC7HHqW0LGfuLSue32C9dQ==",
-      "dev": true,
-      "requires": {
-        "@types/redis": "^2.8.0"
       }
     },
     "@types/body-parser": {
@@ -9038,15 +9145,6 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
-    },
-    "@types/redis": {
-      "version": "2.8.32",
-      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.32.tgz",
-      "integrity": "sha512-7jkMKxcGq9p242exlbsVzuJb57KqHRhNl4dHoQu2Y5v9bCAbtIXXH0R3HleSQW4CTOqpHIYUW3t6tpUj4BVQ+w==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/sax": {
       "version": "1.2.4",
@@ -9796,6 +9894,11 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       }
+    },
+    "cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
     },
     "color": {
       "version": "3.2.1",
@@ -11071,6 +11174,11 @@
         "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.2"
       }
+    },
+    "generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g=="
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -12728,6 +12836,19 @@
       "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
       "requires": {
         "resolve": "^1.9.0"
+      }
+    },
+    "redis": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.0.tgz",
+      "integrity": "sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==",
+      "requires": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.0",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
       }
     },
     "reflect-metadata": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "nodemailer": "^6.7.2",
     "nodemon": "^2.0.15",
     "pubsub-js": "^1.9.4",
+    "redis": "^4.7.0",
     "request": "^2.88.2",
     "sass": "^1.49.7",
     "sitemap": "^7.1.1",
@@ -54,7 +55,6 @@
   "devDependencies": {
     "@overnightjs/core": "^1.7.6",
     "@types/adm-zip": "^0.5.0",
-    "@types/apicache": "^1.6.1",
     "@types/compression": "^1.7.2",
     "@types/cookie-parser": "^1.4.2",
     "@types/create-hmac": "^1.1.0",

--- a/src/app/code/admin/services/AdminService.ts
+++ b/src/app/code/admin/services/AdminService.ts
@@ -13,6 +13,7 @@ import { UpdatePromobarMessage } from '../models/UPDATE/UpdatePromobarMessage'
 import { UpdateSiteRestrictions } from '../models/UPDATE/UpdateSiteRestrictions'
 import { UpdateSiteFiles } from '../models/UPDATE/UpdateSiteFiles'
 import { invalidateSiteFileCache } from 'core/utils/siteFiles'
+import { buildAssetCacheKey, cacheDelete } from 'core/utils/dragonfly'
 import { GetReviewsByIdList } from '../models/GET/GetReviewsByIdList'
 import { UpdateReportIgnoreById } from '../models/UPDATE/UpdateReportIgnoreById'
 import { GetReportById } from '../models/GET/GetReportById'
@@ -161,7 +162,9 @@ export class AdminService {
 
     await UpdateReportApproveById(reportId)
     await DeleteReviewById(reportInfo.review_id)
-
+    // The deleted review and adjusted counters are cached on the public asset
+    // page; drop the entry so the moderation is reflected immediately.
+    void cacheDelete(buildAssetCacheKey(reviewInfo.asset_id))
     res.send()
   }
 

--- a/src/app/code/asset/services/AssetService.ts
+++ b/src/app/code/asset/services/AssetService.ts
@@ -50,13 +50,13 @@ interface AssetPageData {
 }
 
 /**
- * Load the shared data behind a public asset page: the asset document, its
- * first page of reviews, the persisted review count and related assets. The
- * four MongoDB operations are consolidated so a Dragonfly cache hit serves the
- * whole page from memory. Mutations that change any of these (reviews, admin
- * review deletion) invalidate the cache key.
+ * Load the shared data behind a public asset page: the asset document, the
+ * requested page of reviews, the persisted review count and related assets.
+ * The four MongoDB operations are consolidated so a Dragonfly cache hit serves
+ * the whole page from memory. Mutations that change any of these (reviews,
+ * admin review deletion) invalidate the cache key.
  */
-async function loadAssetPageData (assetId: string): Promise<AssetPageData> {
+async function loadAssetPageData (assetId: string, reviewsPage = 0): Promise<AssetPageData> {
   const assetInfo = await GetAssetDisplayInformation(assetId)
 
   if (assetInfo === null) {
@@ -72,7 +72,7 @@ async function loadAssetPageData (assetId: string): Promise<AssetPageData> {
   }
 
   const [commentsResult, reviewCountResult, relatedAssetsResult] = await Promise.allSettled([
-    GetAssetReviewsById(assetId, REVIEWS_PER_PAGE, 0),
+    GetAssetReviewsById(assetId, REVIEWS_PER_PAGE, reviewsPage * REVIEWS_PER_PAGE),
     GetAssetReviewCount(assetId),
     GetRelatedAssets(assetInfo.category, assetInfo.godot_version, assetInfo.type, assetInfo.asset_id)
   ])
@@ -135,7 +135,9 @@ export class AssetService {
         // readme render) never leak into the shared cache entry.
         bundle = JSON.parse(JSON.stringify(cached.value)) as AssetPageData
       } else {
-        bundle = await loadAssetPageData(assetId)
+        // Paginated or authenticated views bypass the cache and must load the
+        // requested reviews page (the cached bundle is always page 0).
+        bundle = await loadAssetPageData(assetId, reviewsPage)
       }
       const { assetInfo, comments, reviewCount, relatedAssets } = bundle
 

--- a/src/app/code/asset/services/AssetService.ts
+++ b/src/app/code/asset/services/AssetService.ts
@@ -33,6 +33,59 @@ import { buildAssetUrl } from 'core/utils/assetUrl'
 import { buildCategoryPath } from 'core/utils/taxonomyUrl'
 import { BadRequestError } from 'core/utils/httpError'
 import { attachCardExtras } from 'core/utils/cardView'
+import { buildAssetCacheKey, cacheDelete, cacheGetOrLoad } from 'core/utils/dragonfly'
+
+const REVIEWS_PER_PAGE = 10
+
+const parsedAssetTtl = Number.parseInt(process.env.CACHE_ASSET_TTL_SECONDS ?? '', 10)
+const ASSET_CACHE_TTL_SECONDS = Number.isFinite(parsedAssetTtl) && parsedAssetTtl > 0
+  ? parsedAssetTtl
+  : 30
+
+interface AssetPageData {
+  assetInfo: Awaited<ReturnType<typeof GetAssetDisplayInformation>>
+  comments: Awaited<ReturnType<typeof GetAssetReviewsById>>
+  reviewCount: number
+  relatedAssets: Awaited<ReturnType<typeof GetRelatedAssets>>
+}
+
+/**
+ * Load the shared data behind a public asset page: the asset document, its
+ * first page of reviews, the persisted review count and related assets. The
+ * four MongoDB operations are consolidated so a Dragonfly cache hit serves the
+ * whole page from memory. Mutations that change any of these (reviews, admin
+ * review deletion) invalidate the cache key.
+ */
+async function loadAssetPageData (assetId: string): Promise<AssetPageData> {
+  const assetInfo = await GetAssetDisplayInformation(assetId)
+
+  if (assetInfo === null) {
+    return { assetInfo: null, comments: [], reviewCount: 0, relatedAssets: [] }
+  }
+
+  // Imported asset data is untrusted. Only http(s) URLs may be rendered as
+  // links, otherwise non-HTTP schemes (javascript:, data:, ...) would reach
+  // the browser through the download/repository/issues controls. Sanitizing
+  // here (instead of per request) keeps the cached copy safe too.
+  for (const field of ['download_url', 'browse_url', 'issues_url'] as const) {
+    if (!isSafeHttpUrl(assetInfo[field])) assetInfo[field] = ''
+  }
+
+  const [commentsResult, reviewCountResult, relatedAssetsResult] = await Promise.allSettled([
+    GetAssetReviewsById(assetId, REVIEWS_PER_PAGE, 0),
+    GetAssetReviewCount(assetId),
+    GetRelatedAssets(assetInfo.category, assetInfo.godot_version, assetInfo.type, assetInfo.asset_id)
+  ])
+
+  return {
+    assetInfo,
+    comments: commentsResult.status === 'fulfilled' ? commentsResult.value : [],
+    reviewCount: reviewCountResult.status === 'fulfilled'
+      ? reviewCountResult.value
+      : (commentsResult.status === 'fulfilled' ? commentsResult.value.length : 0),
+    relatedAssets: relatedAssetsResult.status === 'fulfilled' ? relatedAssetsResult.value : []
+  }
+}
 
 export class AssetService {
   /**
@@ -59,7 +112,32 @@ export class AssetService {
     }
 
     try {
-      const assetInfo = await GetAssetDisplayInformation(assetId)
+      const parsedReviewsPage = Number.parseInt(striptags(String(req.query.reviews_page ?? '')), 10)
+      const reviewsPage = Number.isNaN(parsedReviewsPage)
+        ? 0
+        : Math.max(0, Math.min(100, parsedReviewsPage))
+
+      // The public asset page is expensive (~4 Mongo ops). Cache the shared
+      // anonymous default view (page 0) in Dragonfly; authenticated requests,
+      // paginated review views and a shared-cache outage fall back to a direct
+      // load. Entries are invalidated after review/admin writes so fresh
+      // reviews and ratings appear immediately.
+      const cacheable = authToken === '' && reviewsPage === 0
+      let bundle: AssetPageData
+      if (cacheable) {
+        const cached = await cacheGetOrLoad<AssetPageData>(
+          buildAssetCacheKey(assetId),
+          ASSET_CACHE_TTL_SECONDS,
+          async () => await loadAssetPageData(assetId),
+          10_000
+        )
+        // Defensive clone so per-request mutations (saved state, card extras,
+        // readme render) never leak into the shared cache entry.
+        bundle = JSON.parse(JSON.stringify(cached.value)) as AssetPageData
+      } else {
+        bundle = await loadAssetPageData(assetId)
+      }
+      const { assetInfo, comments, reviewCount, relatedAssets } = bundle
 
       if (assetInfo === null) {
         return res.status(StatusCodes.NOT_FOUND).render('templates/pages/lost/not-found', {
@@ -85,42 +163,11 @@ export class AssetService {
         return res.redirect(StatusCodes.MOVED_PERMANENTLY, redirectTarget)
       }
 
-      // Imported asset data is untrusted. Only http(s) URLs may be rendered as
-      // links, otherwise non-HTTP schemes (javascript:, data:, ...) would reach
-      // the browser through the download/repository/issues controls.
-      for (const field of ['download_url', 'browse_url', 'issues_url'] as const) {
-        if (!isSafeHttpUrl(assetInfo[field])) assetInfo[field] = ''
-      }
+      // URLs were sanitized inside loadAssetPageData (shared by cache and
+      // fresh paths), so nothing else needs cleaning here.
 
-      const REVIEWS_PER_PAGE = 10
-      const parsedReviewsPage = Number.parseInt(striptags(String(req.query.reviews_page ?? '')), 10)
-      const reviewsPage = Number.isNaN(parsedReviewsPage)
-        ? 0
-        : Math.max(0, Math.min(100, parsedReviewsPage))
-
-      const comments = await GetAssetReviewsById(assetId, REVIEWS_PER_PAGE, reviewsPage * REVIEWS_PER_PAGE)
       let hasUserReviewedAsset = false
       let usersAssetReview = {}
-
-      let reviewCount = comments.length
-      let relatedAssets: Awaited<ReturnType<typeof GetRelatedAssets>> = []
-
-      try {
-        reviewCount = await GetAssetReviewCount(assetId)
-      } catch (e) {
-        // ignore
-      }
-
-      try {
-        relatedAssets = await GetRelatedAssets(
-          assetInfo.category,
-          assetInfo.godot_version,
-          assetInfo.type,
-          assetInfo.asset_id
-        )
-      } catch (e) {
-        // ignore
-      }
       attachCardExtras(relatedAssets)
 
       assetInfo.modify_date_pretty = fromNow(new Date(assetInfo.modify_date), {
@@ -306,6 +353,10 @@ export class AssetService {
     // Recompute counters from the canonical reviews so upvotes/downvotes and
     // the confidence-adjusted rating_score always match what cards display.
     await RefreshAssetRating(assetId)
+
+    // The public asset page is cached briefly; drop its entry so the review
+    // and its rating change are reflected immediately.
+    void cacheDelete(buildAssetCacheKey(assetId))
 
     res.send()
   }

--- a/src/app/code/dashboard/services/DashboardService.ts
+++ b/src/app/code/dashboard/services/DashboardService.ts
@@ -23,6 +23,7 @@ import { parsePagination } from 'core/utils/pagination'
 import { BadRequestError } from 'core/utils/httpError'
 import { attachCardExtras } from 'core/utils/cardView'
 import { DeleteUserReviewsAndAdjustVotes } from '../models/DELETE/DeleteUserReviewsAndAdjustVotes'
+import { buildUserContextCacheKey, cacheDelete } from 'core/utils/dragonfly'
 
 async function writeResponseChunk (res: Response, chunk: string): Promise<void> {
   if (res.write(chunk)) {
@@ -343,6 +344,10 @@ export class DashboardService {
     const userId = await GetUserIdByToken(hashedToken)
     await DeleteUserReviewsAndAdjustVotes(userId)
     await DeleteUserByUserId(userId)
+
+    // Drop the cached login context so the deleted account can't appear
+    // authenticated for up to the cache TTL.
+    void cacheDelete(buildUserContextCacheKey(hashedToken))
 
     res.clearCookie('auth-token')
     res.redirect('/')

--- a/src/app/code/homepage/services/HomepageService.ts
+++ b/src/app/code/homepage/services/HomepageService.ts
@@ -9,24 +9,52 @@ import { GetLastModifiedAssets } from '../models/GET/GetLastModifiedAssets'
 import { GetTrendingAssets } from '../models/GET/GetTrendingAssets'
 import { getAllGuides } from 'app/code/guides/models/guide'
 import { attachCardExtras } from 'core/utils/cardView'
+import { cacheGetOrLoad } from 'core/utils/dragonfly'
+
+interface HomepageSnapshot {
+  trendingAssets: any[]
+  featuredAssets: any[]
+  lastModifiedAssets: any[]
+  categoriesObject: any
+}
+
+const parsedHomepageTtl = Number.parseInt(process.env.CACHE_HOMEPAGE_TTL_SECONDS ?? '', 10)
+const HOMEPAGE_CACHE_TTL_SECONDS = Number.isFinite(parsedHomepageTtl) && parsedHomepageTtl > 0
+  ? parsedHomepageTtl
+  : 60
+
+async function loadHomepageSnapshot (): Promise<HomepageSnapshot> {
+  // Fetch sections concurrently and degrade per-section instead of failing the
+  // whole homepage when one query hiccups.
+  const [trending, featured, lastModified, categories] = await Promise.allSettled([
+    GetTrendingAssets(),
+    GetFourAssetsForHomepage(),
+    GetLastModifiedAssets(),
+    GetAllCategoriesAndTheirAssetCount()
+  ])
+
+  return {
+    trendingAssets: trending.status === 'fulfilled' ? trending.value : [],
+    featuredAssets: featured.status === 'fulfilled' ? featured.value : [],
+    lastModifiedAssets: lastModified.status === 'fulfilled' ? lastModified.value : [],
+    categoriesObject: categories.status === 'fulfilled' ? categories.value : {}
+  }
+}
 
 export class HomepageService {
   public async render (req: Request, res: Response): Promise<void> {
     const authToken = striptags(req.cookies['auth-token'] ?? '')
 
-    // Fetch sections concurrently and degrade per-section instead of failing the
-    // whole homepage when one query hiccups.
-    const [trending, featured, lastModified, categories] = await Promise.allSettled([
-      GetTrendingAssets(),
-      GetFourAssetsForHomepage(),
-      GetLastModifiedAssets(),
-      GetAllCategoriesAndTheirAssetCount()
-    ])
-
-    const trendingAssets = trending.status === 'fulfilled' ? trending.value : []
-    const featuredAssets = featured.status === 'fulfilled' ? featured.value : []
-    const lastModifiedAssets = lastModified.status === 'fulfilled' ? lastModified.value : []
-    const categoriesObject = categories.status === 'fulfilled' ? categories.value : {}
+    const cached = await cacheGetOrLoad(
+      'gda:v1:homepage',
+      HOMEPAGE_CACHE_TTL_SECONDS,
+      loadHomepageSnapshot,
+      10_000
+    )
+    // Card decoration and saved-state are request-specific mutations. Clone
+    // the shared cached value so one request can never alter another.
+    const snapshot = JSON.parse(JSON.stringify(cached.value)) as HomepageSnapshot
+    const { trendingAssets, featuredAssets, lastModifiedAssets, categoriesObject } = snapshot
 
     attachCardExtras(trendingAssets)
     attachCardExtras(featuredAssets)

--- a/src/app/code/search/services/SearchService.ts
+++ b/src/app/code/search/services/SearchService.ts
@@ -2,8 +2,8 @@ import { Request, Response } from 'express'
 import { TokenServices } from 'core/modules/authentication/services/TokenServices'
 import { GetUserSavedAssets } from 'app/code/dashboard/models/GET/GetUserSavedAssets'
 import striptags from 'striptags'
-import { GetSearchResults } from '../models/GET/GetSearchResults'
-import { GetSearchFacets } from '../models/GET/GetSearchFacets'
+import { GetSearchResults, SearchResults } from '../models/GET/GetSearchResults'
+import { GetSearchFacets, SearchFacets } from '../models/GET/GetSearchFacets'
 import { GetRelatedAssets } from 'app/code/asset/models/GET/GetRelatedAssets'
 import { SearchFilterOptions } from '../models/GET/buildSearchFilter'
 import { parseSearchRequest } from './parseSearchRequest'
@@ -12,6 +12,39 @@ import { displayCategoryLabel } from 'core/utils/taxonomyUrl'
 import { getCategoryContent } from './categoryContent'
 import { escapeHtml } from 'core/utils/escapeHtml'
 import { attachCardExtras } from 'core/utils/cardView'
+import { cacheGetOrLoad } from 'core/utils/dragonfly'
+
+interface CachedSearchData {
+  searchData: SearchResults
+  facets: SearchFacets
+}
+
+const parsedSearchTtl = Number.parseInt(process.env.CACHE_SEARCH_TTL_SECONDS ?? '', 10)
+const SEARCH_CACHE_TTL_SECONDS = Number.isFinite(parsedSearchTtl) && parsedSearchTtl > 0
+  ? parsedSearchTtl
+  : 60
+
+function searchCacheKey (
+  query: string,
+  limit: number,
+  skip: number,
+  sort: string,
+  options: SearchFilterOptions
+): string {
+  // Parsing already deduplicates/caps filters. Sort copies here so equivalent
+  // parameter orderings share one key and cannot inflate cache cardinality.
+  return `gda:v1:search:${Buffer.from(JSON.stringify({
+    query,
+    limit,
+    skip,
+    sort,
+    categories: [...(options.categories ?? [])].sort(),
+    engines: [...(options.engines ?? [])].sort(),
+    types: [...(options.types ?? [])].sort(),
+    supports: [...(options.supports ?? [])].sort(),
+    featured: options.featured === true
+  })).toString('base64url')}`
+}
 
 export class SearchService {
   public async render (req: Request, res: Response): Promise<void> {
@@ -30,10 +63,20 @@ export class SearchService {
     // four facets are consolidated into another, so the per-request Mongo
     // fan-out drops from ~6 operations to ~2, directly relieving the pool
     // pressure that caused the prod 503s.
-    const [searchData, facets] = await Promise.all([
-      GetSearchResults(parsed.query, parsed.limit, parsed.skip, parsed.sort, filterOptions),
-      GetSearchFacets(parsed.query, filterOptions)
-    ])
+    const cached = await cacheGetOrLoad<CachedSearchData>(
+      searchCacheKey(parsed.query, parsed.limit, parsed.skip, parsed.sort, filterOptions),
+      SEARCH_CACHE_TTL_SECONDS,
+      async () => {
+        const [searchData, facets] = await Promise.all([
+          GetSearchResults(parsed.query, parsed.limit, parsed.skip, parsed.sort, filterOptions),
+          GetSearchFacets(parsed.query, filterOptions)
+        ])
+        return { searchData, facets }
+      },
+      10_000
+    )
+    // attachCardExtras and authenticated saved-state mutate asset objects.
+    const { searchData, facets } = JSON.parse(JSON.stringify(cached.value)) as CachedSearchData
     const { assets, total: totalAssetsForQuery } = searchData
 
     attachCardExtras(assets)

--- a/src/core/RouterServer.ts
+++ b/src/core/RouterServer.ts
@@ -22,27 +22,8 @@ let promoCacheExpiresAt = 0
 let promoRefresh: Promise<void> | null = null
 const PROMO_TTL_MS = 60_000
 
-// Cap on in-flight dynamic HTTP requests (process-wide). This is the "Server
-// is busy" 503 backstop, and it was the actual cause of the prod 503s: at
-// ~46 req/s (120M/month) a cap of 100 saturates whenever the average request
-// takes more than ~2.2s, which bursts easily reach while crawling. Raised to
-// 500 in tandem with the search fan-out consolidation (6 -> 2 Mongo ops per
-// request) and the MONGO_MAX_POOL bump, so worst-case pool demand stays
-// bounded (~cap x 2). Tune with MAX_CONCURRENT_REQUESTS and watch
-// /metrics http_peak_active_requests + http_requests_rejected_active_cap_total.
-const parsedMaxRequests = Number.parseInt(process.env.MAX_CONCURRENT_REQUESTS ?? '', 10)
-const MAX_CONCURRENT_REQUESTS = Number.isFinite(parsedMaxRequests) && parsedMaxRequests > 0 ? parsedMaxRequests : 500
-
 const parsedTelemetryInterval = Number.parseInt(process.env.TELEMETRY_LOG_INTERVAL_MS ?? '', 10)
 const TELEMETRY_LOG_INTERVAL_MS = Number.isFinite(parsedTelemetryInterval) && parsedTelemetryInterval > 0 ? parsedTelemetryInterval : 60_000
-
-let activeRequests = 0
-
-// Throttle the per-rejection log so a sustained overload burst can't flood
-// Docker's log driver while the server is already under pressure.
-const REJECT_LOG_INTERVAL_MS = 5000
-let lastRejectLogAt = 0
-let rejectedSinceLastLog = 0
 
 function refreshPromoMessage (): void {
   if (promoRefresh !== null) {
@@ -160,9 +141,9 @@ class RouterServer extends Server {
       res.send('OK')
     })
 
-    // Prometheus-format telemetry. Registered before the active-request cap so
-    // it stays reachable while the app is under load, like /health. Process and
-    // system metrics are only sensitive if someone can reach this route, so it
+    // Prometheus-format telemetry. Registered early so it stays reachable
+    // while the app is under load, like /health. Process and system metrics
+    // are only sensitive if someone can reach this route, so it
     // is gated behind an optional bearer token for production; leaving
     // METRICS_TOKEN unset keeps it open (e.g. local dev).
     this.app.get('/metrics', (req: Request, res: Response) => {
@@ -177,42 +158,19 @@ class RouterServer extends Server {
       res.send(telemetry.prometheusText())
     })
 
-    // Bound request state retained during traffic spikes or database pressure.
-    // Every admitted request is timed and recorded by telemetry; rejections
-    // increment a counter and are logged (throttled) so capacity limits stay
-    // visible in the logs and on /metrics.
-    this.app.use((req: Request, res: Response, next: NextFunction) => {
-      if (activeRequests >= MAX_CONCURRENT_REQUESTS) {
-        // Rejected requests never enter telemetry's active gauge or totals, so
-        // http_peak_active_requests can't exceed the cap and http_requests_total
-        // only counts work the server actually admitted.
-        telemetry.requestRejectedByActiveCap()
-        rejectedSinceLastLog++
-        const now = Date.now()
-        if (now - lastRejectLogAt >= REJECT_LOG_INTERVAL_MS) {
-          lastRejectLogAt = now
-          logger.log('warn', `Rejected ${rejectedSinceLastLog} request(s) at the active-request cap`, {
-            active: activeRequests,
-            max: MAX_CONCURRENT_REQUESTS,
-            method: req.method,
-            path: req.path,
-            ua: req.get('user-agent')
-          })
-          rejectedSinceLastLog = 0
-        }
-        res.setHeader('Retry-After', '1')
-        res.status(StatusCodes.SERVICE_UNAVAILABLE).send({ error: 'Server is busy, please try again shortly' })
-        return
-      }
-
+    // Track every dynamic request for telemetry (active/peak gauges plus
+    // duration/status stats) without rejecting anything. There is deliberately
+    // no in-flight request cap: cached reads are cheap, and uncached work
+    // either completes or trips MongoDB's fail-fast timeouts and surfaces as a
+    // real error instead of a synthetic 503. Watch http_active_requests and
+    // http_request_duration_p99_ms on /metrics during bursts.
+    this.app.use((_req: Request, res: Response, next: NextFunction) => {
       telemetry.requestStart()
-      activeRequests++
       let released = false
       const startedAt = Date.now()
       const release = (): void => {
         if (!released) {
           released = true
-          activeRequests--
           telemetry.requestEnd(Date.now() - startedAt, res.statusCode)
         }
       }

--- a/src/core/modules/authentication/controllers/users/UserController.ts
+++ b/src/core/modules/authentication/controllers/users/UserController.ts
@@ -7,6 +7,7 @@ import rateLimit from 'express-rate-limit'
 import { PasswordHasherBusyError } from 'core/modules/authentication/services/PasswordHasher'
 import { TokenServices } from 'core/modules/authentication/services/TokenServices'
 import { DeleteResumeToken } from 'core/modules/authentication/models/user/DELETE/DeleteResumeToken'
+import { buildUserContextCacheKey, cacheDelete } from 'core/utils/dragonfly'
 
 const urlencodedParser = bodyParser.urlencoded({ extended: false })
 
@@ -102,6 +103,9 @@ export class UserController {
       } catch (e) {
         // token revocation is best-effort; the cookie is still cleared
       }
+      // Drop the cached login context so a logged-out session can't appear
+      // authenticated for up to the cache TTL.
+      void cacheDelete(buildUserContextCacheKey(hashedToken))
     }
     res.clearCookie('auth-token')
     res.redirect('/')

--- a/src/core/modules/authentication/models/user/GET/GetUserContextByToken.ts
+++ b/src/core/modules/authentication/models/user/GET/GetUserContextByToken.ts
@@ -17,12 +17,12 @@ const USER_CONTEXT_CACHE_TTL_SECONDS = Number.isFinite(parsedUserCtxTtl) && pars
  * TTL so the per-request global auth lookup stops hitting MongoDB on every
  * authenticated page view.
  */
-async function loadUserContext (token: string): Promise<UserContext> {
+async function loadUserContext (hashedToken: string): Promise<UserContext> {
   const mongo = MongoHelper.getDatabase()
   const user = await mongo.collection('users').findOne({
     resume_tokens: {
       $elemMatch: {
-        token,
+        token: hashedToken,
         expires: { $gt: new Date() }
       }
     }
@@ -40,11 +40,11 @@ async function loadUserContext (token: string): Promise<UserContext> {
  * The key is invalidated on logout and account deletion; a stale entry can
  * only outlive a revocation by at most the TTL.
  */
-export async function GetUserContextByToken (token: string): Promise<UserContext> {
+export async function GetUserContextByToken (hashedToken: string): Promise<UserContext> {
   const cached = await cacheGetOrLoad<UserContext>(
-    buildUserContextCacheKey(token),
+    buildUserContextCacheKey(hashedToken),
     USER_CONTEXT_CACHE_TTL_SECONDS,
-    async () => await loadUserContext(token)
+    async () => await loadUserContext(hashedToken)
   )
   return cached.value
 }

--- a/src/core/modules/authentication/models/user/GET/GetUserContextByToken.ts
+++ b/src/core/modules/authentication/models/user/GET/GetUserContextByToken.ts
@@ -1,12 +1,23 @@
 import { MongoHelper } from 'core/MongoHelper'
+import { buildUserContextCacheKey, cacheGetOrLoad } from 'core/utils/dragonfly'
 
 interface UserContext {
   loggedIn: boolean
   role?: string
 }
 
-/** Fetch login state and role with one indexed query while rejecting expired tokens. */
-export async function GetUserContextByToken (token: string): Promise<UserContext> {
+const parsedUserCtxTtl = Number.parseInt(process.env.CACHE_USER_CTX_TTL_SECONDS ?? '', 10)
+const USER_CONTEXT_CACHE_TTL_SECONDS = Number.isFinite(parsedUserCtxTtl) && parsedUserCtxTtl > 0
+  ? parsedUserCtxTtl
+  : 30
+
+/**
+ * Load login state and role with one indexed query while rejecting expired
+ * tokens. Runs only on a shared-cache miss; the result is cached for a short
+ * TTL so the per-request global auth lookup stops hitting MongoDB on every
+ * authenticated page view.
+ */
+async function loadUserContext (token: string): Promise<UserContext> {
   const mongo = MongoHelper.getDatabase()
   const user = await mongo.collection('users').findOne({
     resume_tokens: {
@@ -22,4 +33,18 @@ export async function GetUserContextByToken (token: string): Promise<UserContext
   return user === null
     ? { loggedIn: false }
     : { loggedIn: true, role: user.role as string | undefined }
+}
+
+/**
+ * Fetch login state and role, cached in Dragonfly (short TTL, fail-open).
+ * The key is invalidated on logout and account deletion; a stale entry can
+ * only outlive a revocation by at most the TTL.
+ */
+export async function GetUserContextByToken (token: string): Promise<UserContext> {
+  const cached = await cacheGetOrLoad<UserContext>(
+    buildUserContextCacheKey(token),
+    USER_CONTEXT_CACHE_TTL_SECONDS,
+    async () => await loadUserContext(token)
+  )
+  return cached.value
 }

--- a/src/core/start.ts
+++ b/src/core/start.ts
@@ -8,6 +8,7 @@ import { runMigrations } from 'core/migrations'
 import { runGenerateSitemap } from 'app/utilities/sitemapGenerator/jobs/generateSitemap'
 import { getWorkerCount } from 'core/utils/clusterConfig'
 import { invalidateSiteFileCacheLocally, primeSiteFilesCache } from 'core/utils/siteFiles'
+import { disconnectDragonfly } from 'core/utils/dragonfly'
 
 process.on('uncaughtException', (err) => {
   console.error('Uncaught Exception:', err)
@@ -106,6 +107,7 @@ if (cluster.isPrimary) {
       for (const id of Object.keys(cluster.workers ?? {})) {
         cluster.workers?.[id]?.kill('SIGTERM')
       }
+      void disconnectDragonfly()
       MongoHelper.getInstance().disconnect()
       process.exit(0)
     }
@@ -127,6 +129,12 @@ if (cluster.isPrimary) {
       invalidateSiteFileCacheLocally()
     }
   })
+
+  const shutdownWorker = (): void => {
+    void disconnectDragonfly().finally(() => process.exit(0))
+  }
+  process.on('SIGTERM', shutdownWorker)
+  process.on('SIGINT', shutdownWorker)
 
   MongoHelper.getInstance().connect().then(() => {
     const startTime: Date = new Date()

--- a/src/core/utils/dragonfly.ts
+++ b/src/core/utils/dragonfly.ts
@@ -177,6 +177,15 @@ export function buildAssetCacheKey (assetId: string): string {
   return `gda:v1:asset:${assetId}`
 }
 
+/**
+ * Cache key for an authenticated user's login context (loggedIn + role),
+ * derived from the hashed resume token. Invalidated on logout and account
+ * deletion so a revoked session never outlives its short TTL.
+ */
+export function buildUserContextCacheKey (hashedToken: string): string {
+  return `gda:v1:userctx:${hashedToken}`
+}
+
 export async function disconnectDragonfly (): Promise<void> {
   const connected = client
   client = null

--- a/src/core/utils/dragonfly.ts
+++ b/src/core/utils/dragonfly.ts
@@ -169,6 +169,14 @@ export async function cacheGetOrLoad<T> (
   return { value: await loader(), hit: false }
 }
 
+/**
+ * Cache key for a public asset (PDP) page bundle. Shared by the render path
+ * and by the mutation paths that invalidate it after a review or admin change.
+ */
+export function buildAssetCacheKey (assetId: string): string {
+  return `gda:v1:asset:${assetId}`
+}
+
 export async function disconnectDragonfly (): Promise<void> {
   const connected = client
   client = null

--- a/src/core/utils/dragonfly.ts
+++ b/src/core/utils/dragonfly.ts
@@ -56,10 +56,16 @@ async function getClient (): Promise<DragonflyClient | null> {
         reconnectStrategy: false
       }
     }) as DragonflyClient
-    next.on('error', () => {
-      // Cache failures are handled as misses. Avoid logging every client event
-      // while Dragonfly is unavailable; the connection attempt logs once.
-    })
+    const markDead = (): void => {
+      // Only the active client clears itself; a late event from an older
+      // client must never clobber a newer, healthy reference.
+      if (client === next) client = null
+    }
+    // Cache failures are handled as misses. When the connection drops, clear
+    // the module reference so the next call reconnects cleanly; the initial
+    // connect attempt logs the one-time "unavailable" warning.
+    next.on('end', markDead)
+    next.on('error', markDead)
 
     try {
       await next.connect()

--- a/src/core/utils/dragonfly.ts
+++ b/src/core/utils/dragonfly.ts
@@ -1,0 +1,182 @@
+import { createClient, RedisClientType } from 'redis'
+import { randomBytes } from 'crypto'
+import { logger } from 'core/utils/logger'
+import * as telemetry from 'core/utils/telemetry'
+
+type DragonflyClient = RedisClientType
+
+const DEFAULT_URL = 'redis://dragonfly:6379'
+const CONNECT_TIMEOUT_MS = 1000
+const COMMAND_TIMEOUT_MS = 750
+const RECONNECT_DELAY_MS = 10_000
+const DEFAULT_LOCK_MS = 5000
+const DEFAULT_WAIT_MS = 1500
+
+let client: DragonflyClient | null = null
+let connectPromise: Promise<DragonflyClient | null> | null = null
+let lastConnectAttemptAt = 0
+
+function isEnabled (): boolean {
+  return process.env.CACHE_ENABLED !== 'false'
+}
+
+function cacheUrl (): string {
+  const configured = process.env.DRAGONFLY_URL?.trim()
+  return configured !== undefined && configured !== '' ? configured : DEFAULT_URL
+}
+
+async function withTimeout<T> (operation: Promise<T>, timeoutMs = COMMAND_TIMEOUT_MS): Promise<T> {
+  return await new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Dragonfly command timed out after ${timeoutMs}ms`)), timeoutMs)
+    timer.unref()
+    operation.then(value => {
+      clearTimeout(timer)
+      resolve(value)
+    }).catch(error => {
+      clearTimeout(timer)
+      reject(error)
+    })
+  })
+}
+
+async function getClient (): Promise<DragonflyClient | null> {
+  if (!isEnabled()) return null
+  if (client?.isReady === true) return client
+  if (connectPromise !== null) return await connectPromise
+
+  const now = Date.now()
+  if (now - lastConnectAttemptAt < RECONNECT_DELAY_MS) return null
+  lastConnectAttemptAt = now
+
+  connectPromise = (async () => {
+    const next = createClient({
+      url: cacheUrl(),
+      socket: {
+        connectTimeout: CONNECT_TIMEOUT_MS,
+        reconnectStrategy: false
+      }
+    }) as DragonflyClient
+    next.on('error', () => {
+      // Cache failures are handled as misses. Avoid logging every client event
+      // while Dragonfly is unavailable; the connection attempt logs once.
+    })
+
+    try {
+      await next.connect()
+      client = next
+      logger.log('info', 'Connected to Dragonfly cache')
+      return next
+    } catch (error: any) {
+      logger.log('warn', `Dragonfly unavailable; continuing without shared cache: ${error?.message ?? error}`)
+      if (next.isOpen) await next.disconnect()
+      return null
+    } finally {
+      connectPromise = null
+    }
+  })()
+
+  return await connectPromise
+}
+
+async function cacheCommand<T> (operation: (connected: DragonflyClient) => Promise<T>): Promise<T | null> {
+  const connected = await getClient()
+  if (connected === null) {
+    telemetry.recordCacheBypass()
+    return null
+  }
+
+  try {
+    return await withTimeout(operation(connected))
+  } catch {
+    telemetry.recordCacheError()
+    return null
+  }
+}
+
+export async function cacheGetJson<T> (key: string): Promise<T | null> {
+  const raw = await cacheCommand(async connected => await connected.get(key))
+  if (typeof raw !== 'string') return null
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    telemetry.recordCacheError()
+    void cacheDelete(key)
+    return null
+  }
+}
+
+export async function cacheSetJson (key: string, value: unknown, ttlSeconds: number): Promise<boolean> {
+  if (!Number.isFinite(ttlSeconds) || ttlSeconds <= 0) return false
+  const stored = await cacheCommand(async connected => await connected.set(key, JSON.stringify(value), { EX: Math.ceil(ttlSeconds) }))
+  return stored === 'OK'
+}
+
+export async function cacheDelete (...keys: string[]): Promise<void> {
+  if (keys.length === 0) return
+  await cacheCommand(async connected => await connected.del(keys))
+}
+
+export async function cacheGetOrLoad<T> (
+  key: string,
+  ttlSeconds: number,
+  loader: () => Promise<T>,
+  lockMs = DEFAULT_LOCK_MS
+): Promise<{ value: T, hit: boolean }> {
+  const cached = await cacheGetJson<T>(key)
+  if (cached !== null) {
+    telemetry.recordCacheHit()
+    return { value: cached, hit: true }
+  }
+
+  const connected = await getClient()
+  if (connected === null) {
+    telemetry.recordCacheMiss()
+    return { value: await loader(), hit: false }
+  }
+
+  const lockKey = `${key}:lock`
+  const lockToken = `${process.pid}:${randomBytes(8).toString('hex')}`
+  const acquired = await cacheCommand(async current => await current.set(lockKey, lockToken, { NX: true, PX: lockMs }))
+
+  if (acquired === 'OK') {
+    try {
+      const value = await loader()
+      await cacheSetJson(key, value, ttlSeconds)
+      telemetry.recordCacheMiss()
+      return { value, hit: false }
+    } finally {
+      const currentLock = await cacheCommand(async current => await current.get(lockKey))
+      if (currentLock === lockToken) await cacheDelete(lockKey)
+    }
+  }
+
+  // Another worker is filling this key. Wait briefly for its result instead
+  // of stampeding MongoDB, but never make Dragonfly a hard dependency.
+  const deadline = Date.now() + Math.min(DEFAULT_WAIT_MS, lockMs)
+  while (Date.now() < deadline) {
+    await new Promise<void>(resolve => {
+      const timer = setTimeout(resolve, 25)
+      timer.unref()
+    })
+    const filled = await cacheGetJson<T>(key)
+    if (filled !== null) {
+      telemetry.recordCacheHit()
+      return { value: filled, hit: true }
+    }
+  }
+
+  telemetry.recordCacheMiss()
+  return { value: await loader(), hit: false }
+}
+
+export async function disconnectDragonfly (): Promise<void> {
+  const connected = client
+  client = null
+  if (connected?.isOpen === true) {
+    try {
+      await connected.quit()
+    } catch {
+      void connected.disconnect()
+    }
+  }
+}

--- a/src/core/utils/telemetry.ts
+++ b/src/core/utils/telemetry.ts
@@ -27,6 +27,10 @@ export interface TelemetrySnapshot {
   rejectedByActiveCap: number
   mongoWaitQueueTimeouts: number
   mongoServerSelectionErrors: number
+  cacheHits: number
+  cacheMisses: number
+  cacheBypasses: number
+  cacheErrors: number
   status2xx: number
   status3xx: number
   status4xx: number
@@ -50,6 +54,10 @@ let totalRejected = 0
 let rejectedByActiveCap = 0
 let mongoWaitQueueTimeouts = 0
 let mongoServerSelectionErrors = 0
+let cacheHits = 0
+let cacheMisses = 0
+let cacheBypasses = 0
+let cacheErrors = 0
 let status2xx = 0
 let status3xx = 0
 let status4xx = 0
@@ -137,6 +145,22 @@ export function recordMongoServerSelectionError (): void {
   mongoServerSelectionErrors++
 }
 
+export function recordCacheHit (): void {
+  cacheHits++
+}
+
+export function recordCacheMiss (): void {
+  cacheMisses++
+}
+
+export function recordCacheBypass (): void {
+  cacheBypasses++
+}
+
+export function recordCacheError (): void {
+  cacheErrors++
+}
+
 function percentile (p: number): number {
   const count = durations.length
   if (count === 0) {
@@ -158,6 +182,10 @@ export function snapshot (): TelemetrySnapshot {
     rejectedByActiveCap,
     mongoWaitQueueTimeouts,
     mongoServerSelectionErrors,
+    cacheHits,
+    cacheMisses,
+    cacheBypasses,
+    cacheErrors,
     status2xx,
     status3xx,
     status4xx,
@@ -202,6 +230,10 @@ export function prometheusText (): string {
   emit('gauge', 'http_request_duration_p99_ms', 'p99 recent request duration in ms', s.durationP99Ms)
   emit('counter', 'mongo_wait_queue_timeouts_total', 'MongoDB connection checkout (wait-queue) timeouts', s.mongoWaitQueueTimeouts)
   emit('counter', 'mongo_server_selection_errors_total', 'MongoDB server-selection errors', s.mongoServerSelectionErrors)
+  emit('counter', 'cache_hits_total', 'Shared Dragonfly cache hits', s.cacheHits)
+  emit('counter', 'cache_misses_total', 'Shared Dragonfly cache misses filled from the source', s.cacheMisses)
+  emit('counter', 'cache_bypasses_total', 'Operations bypassing the shared cache while disabled or unavailable', s.cacheBypasses)
+  emit('counter', 'cache_errors_total', 'Shared Dragonfly cache command or payload errors', s.cacheErrors)
   emit('gauge', 'process_uptime_seconds', 'Seconds since this process started', s.uptimeSeconds)
   emit('gauge', 'process_rss_bytes', 'Resident set size in bytes', memory.rss)
   emit('gauge', 'process_heap_used_bytes', 'V8 heap used in bytes', memory.heapUsed)
@@ -250,6 +282,10 @@ export function reset (): void {
   rejectedByActiveCap = 0
   mongoWaitQueueTimeouts = 0
   mongoServerSelectionErrors = 0
+  cacheHits = 0
+  cacheMisses = 0
+  cacheBypasses = 0
+  cacheErrors = 0
   status2xx = 0
   status3xx = 0
   status4xx = 0

--- a/src/core/utils/telemetry.ts
+++ b/src/core/utils/telemetry.ts
@@ -3,13 +3,12 @@ import { logger } from 'core/utils/logger'
 
 /**
  * Lightweight process-wide telemetry for the HTTP request lifecycle and
- * MongoDB pool health. This exists so production capacity decisions (the
- * MAX_CONCURRENT_REQUESTS cap, MONGO_MAX_POOL, caching) are driven by real
- * numbers instead of guesses:
+ * MongoDB pool health. This exists so production capacity decisions (pool
+ * sizing, caching, scaling) are driven by real numbers instead of guesses:
  *
  * - Gauges: active/peak requests, uptime, memory, load average.
- * - Counters: total served, rejected-by-cap, 2xx/3xx/4xx/5xx, Mongo pool
- *   checkout (wait-queue) timeouts, Mongo server-selection errors.
+ * - Counters: total served, 2xx/3xx/4xx/5xx, Mongo pool checkout
+ *   (wait-queue) timeouts, Mongo server-selection errors.
  * - A ring buffer of recent request durations so p50/p95/p99 stay cheap and
  *   bounded (~4k samples, no unbounded growth).
  *
@@ -23,8 +22,6 @@ export interface TelemetrySnapshot {
   activeRequests: number
   peakActiveRequests: number
   totalRequests: number
-  totalRejected: number
-  rejectedByActiveCap: number
   mongoWaitQueueTimeouts: number
   mongoServerSelectionErrors: number
   cacheHits: number
@@ -50,8 +47,6 @@ const startedAt = Date.now()
 let activeRequests = 0
 let peakActiveRequests = 0
 let totalRequests = 0
-let totalRejected = 0
-let rejectedByActiveCap = 0
 let mongoWaitQueueTimeouts = 0
 let mongoServerSelectionErrors = 0
 let cacheHits = 0
@@ -69,7 +64,7 @@ let durationSum = 0
 let durationMin = Number.POSITIVE_INFINITY
 let durationMax = 0
 
-/** Record that a dynamic request entered the server (before the cap check). */
+/** Record that a dynamic request entered the server. */
 export function requestStart (): void {
   activeRequests++
   totalRequests++
@@ -125,16 +120,6 @@ export function requestEnd (durationMs: number, statusCode: number): void {
   }
 }
 
-/**
- * Record a request rejected by the active-request cap (the 503 backstop).
- * Rejected requests never entered the active gauge (requestStart runs only
- * for admitted requests), so this only bumps the rejection counters.
- */
-export function requestRejectedByActiveCap (): void {
-  totalRejected++
-  rejectedByActiveCap++
-}
-
 /** Record a MongoDB driver "timed out checking out a connection" error. */
 export function recordMongoWaitQueueTimeout (): void {
   mongoWaitQueueTimeouts++
@@ -178,8 +163,6 @@ export function snapshot (): TelemetrySnapshot {
     activeRequests,
     peakActiveRequests,
     totalRequests,
-    totalRejected,
-    rejectedByActiveCap,
     mongoWaitQueueTimeouts,
     mongoServerSelectionErrors,
     cacheHits,
@@ -216,8 +199,6 @@ export function prometheusText (): string {
   emit('gauge', 'http_active_requests', 'In-flight dynamic HTTP requests in this process', s.activeRequests)
   emit('gauge', 'http_peak_active_requests', 'Peak concurrent dynamic HTTP requests since boot', s.peakActiveRequests)
   emit('counter', 'http_requests_total', 'Total dynamic HTTP requests admitted to the server', s.totalRequests)
-  emit('counter', 'http_requests_rejected_total', 'Requests rejected before handling', s.totalRejected)
-  emit('counter', 'http_requests_rejected_active_cap_total', 'Requests rejected by the active-request cap (503)', s.rejectedByActiveCap)
   emit('counter', 'http_requests_2xx_total', 'Responses with status 200-299', s.status2xx)
   emit('counter', 'http_requests_3xx_total', 'Responses with status 300-399', s.status3xx)
   emit('counter', 'http_requests_4xx_total', 'Responses with status 400-499', s.status4xx)
@@ -278,8 +259,6 @@ export function reset (): void {
   activeRequests = 0
   peakActiveRequests = 0
   totalRequests = 0
-  totalRejected = 0
-  rejectedByActiveCap = 0
   mongoWaitQueueTimeouts = 0
   mongoServerSelectionErrors = 0
   cacheHits = 0

--- a/tests/dragonfly-cache.test.ts
+++ b/tests/dragonfly-cache.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { cacheGetOrLoad } from '../src/core/utils/dragonfly'
+import { cacheGetOrLoad, buildAssetCacheKey } from '../src/core/utils/dragonfly'
 import { reset, snapshot } from '../src/core/utils/telemetry'
 
 describe('Dragonfly cache', () => {
@@ -27,5 +27,10 @@ describe('Dragonfly cache', () => {
         process.env.CACHE_ENABLED = previous
       }
     }
+  })
+
+  it('builds a stable asset page cache key', () => {
+    assert.equal(buildAssetCacheKey('abc-123'), 'gda:v1:asset:abc-123')
+    assert.equal(buildAssetCacheKey('abc-123'), buildAssetCacheKey('abc-123'))
   })
 })

--- a/tests/dragonfly-cache.test.ts
+++ b/tests/dragonfly-cache.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { cacheGetOrLoad, buildAssetCacheKey } from '../src/core/utils/dragonfly'
+import { cacheGetOrLoad, buildAssetCacheKey, buildUserContextCacheKey } from '../src/core/utils/dragonfly'
 import { reset, snapshot } from '../src/core/utils/telemetry'
 
 describe('Dragonfly cache', () => {
@@ -32,5 +32,10 @@ describe('Dragonfly cache', () => {
   it('builds a stable asset page cache key', () => {
     assert.equal(buildAssetCacheKey('abc-123'), 'gda:v1:asset:abc-123')
     assert.equal(buildAssetCacheKey('abc-123'), buildAssetCacheKey('abc-123'))
+  })
+
+  it('builds a stable user context cache key', () => {
+    assert.equal(buildUserContextCacheKey('tok-1'), 'gda:v1:userctx:tok-1')
+    assert.equal(buildUserContextCacheKey('tok-1'), buildUserContextCacheKey('tok-1'))
   })
 })

--- a/tests/dragonfly-cache.test.ts
+++ b/tests/dragonfly-cache.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { cacheGetOrLoad } from '../src/core/utils/dragonfly'
+import { reset, snapshot } from '../src/core/utils/telemetry'
+
+describe('Dragonfly cache', () => {
+  it('falls back to the loader when the shared cache is disabled', async () => {
+    const previous = process.env.CACHE_ENABLED
+    process.env.CACHE_ENABLED = 'false'
+    reset()
+    let loads = 0
+
+    try {
+      const result = await cacheGetOrLoad('test:disabled', 60, async () => {
+        loads++
+        return { ok: true }
+      })
+
+      assert.deepEqual(result, { value: { ok: true }, hit: false })
+      assert.equal(loads, 1)
+      assert.equal(snapshot().cacheMisses, 1)
+      assert.equal(snapshot().cacheBypasses, 1)
+    } finally {
+      if (previous === undefined) {
+        delete process.env.CACHE_ENABLED
+      } else {
+        process.env.CACHE_ENABLED = previous
+      }
+    }
+  })
+})

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -7,6 +7,10 @@ import {
   requestRejectedByActiveCap,
   recordMongoWaitQueueTimeout,
   recordMongoServerSelectionError,
+  recordCacheHit,
+  recordCacheMiss,
+  recordCacheBypass,
+  recordCacheError,
   prometheusText,
   reset
 } from '../src/core/utils/telemetry'
@@ -88,6 +92,20 @@ describe('telemetry', () => {
     assert.equal(s.mongoServerSelectionErrors, 1)
   })
 
+  it('counts shared cache outcomes separately', () => {
+    reset()
+    recordCacheHit()
+    recordCacheHit()
+    recordCacheMiss()
+    recordCacheBypass()
+    recordCacheError()
+    const s = snapshot()
+    assert.equal(s.cacheHits, 2)
+    assert.equal(s.cacheMisses, 1)
+    assert.equal(s.cacheBypasses, 1)
+    assert.equal(s.cacheErrors, 1)
+  })
+
   it('renders Prometheus text with expected metric names', () => {
     reset()
     requestStart()
@@ -98,5 +116,6 @@ describe('telemetry', () => {
     assert.match(text, /http_requests_total 1/)
     assert.match(text, /http_request_duration_p95_ms 5/)
     assert.match(text, /mongo_wait_queue_timeouts_total 0/)
+    assert.match(text, /cache_hits_total 0/)
   })
 })

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -4,7 +4,6 @@ import {
   snapshot,
   requestStart,
   requestEnd,
-  requestRejectedByActiveCap,
   recordMongoWaitQueueTimeout,
   recordMongoServerSelectionError,
   recordCacheHit,
@@ -32,18 +31,6 @@ describe('telemetry', () => {
     requestEnd(20, 404)
     assert.equal(snapshot().activeRequests, 0)
     assert.equal(snapshot().status4xx, 1)
-  })
-
-  it('records a cap rejection without touching the active count', () => {
-    reset()
-    requestStart()
-    requestStart()
-    assert.equal(snapshot().activeRequests, 2)
-    requestRejectedByActiveCap()
-    // A rejected request never entered the active gauge, so it must stay put.
-    assert.equal(snapshot().activeRequests, 2)
-    assert.equal(snapshot().totalRejected, 1)
-    assert.equal(snapshot().rejectedByActiveCap, 1)
   })
 
   it('computes duration percentiles and average', () => {


### PR DESCRIPTION
### Goal:
Add a shared in-memory cache (Dragonfly — Redis-protocol) and remove the synthetic
request cap so the site can absorb millions of hits/day on a single 6-core / 7 GB
host without a MongoDB round-trip on every request and without rejecting traffic
with "Server is busy" 503s.

What this MR delivers:
- **Dragonfly service** (pinned `v1.35.1`) added to the production Compose stack —
  cache mode, 512 MB maxmemory, private network, one IO thread; fail-open client
  with short timeouts and distributed single-flight fills (no cache stampedes).
- **Shared caches** (default 60s TTL, tunable via `CACHE_*_TTL_SECONDS` env vars):
  - Homepage snapshot (4 Mongo ops → 0 on hit)
  - Normalized search results + facets
  - Anonymous asset/PDP default view (invalidated on review/admin writes so
    fresh reviews/ratings appear immediately)
  - Authenticated login context (30s TTL; invalidated on logout/account delete)
- **Cache telemetry** — hit/miss/bypass/error counters on `/metrics`.
- **Removed the `MAX_CONCURRENT_REQUESTS` active-request cap** (the 503
  "Server is busy" backstop). The middleware is now telemetry-tracking only;
  overload surfaces as real errors (Mongo fail-fast timeouts) instead of a
  synthetic 503.
- **Production view caching** enabled (`NODE_ENV=production`) so Eta templates
  compile once, not per request.
- Every cache path is **fail-open**: if Dragonfly is down or
  `CACHE_ENABLED=false`, the app falls back to the existing MongoDB queries.

### Checklist
- [x] The changes are scoped appropriately
- [x] The project builds and runs successfully
- [x] I have self reviewed the changes