### PR TITLE
Feat/traffic resilience

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,14 +21,30 @@ IMGPROXY_HOST=https://img.godotassetlibrary.com
 IMGPROXY_ENABLED=true
 PROJECT_BASE_URL=https://godotassetlibrary.com
 
-# Shared cache (Dragonfly speaks the Redis protocol). Production Compose sets
-# DRAGONFLY_URL automatically; set CACHE_ENABLED=false for an emergency bypass.
+# Shared cache (Dragonfly speaks the Redis protocol; Compose runs it in cache
+# mode with a 1 GiB budget). Production Compose sets DRAGONFLY_URL
+# automatically; set CACHE_ENABLED=false for an emergency bypass (the app is
+# fail-open either way).
 # DRAGONFLY_URL=redis://dragonfly:6379
 # CACHE_ENABLED=true
-# CACHE_HOMEPAGE_TTL_SECONDS=60
-# CACHE_SEARCH_TTL_SECONDS=60
-# CACHE_ASSET_TTL_SECONDS=30        # asset detail page (reviews + rating; invalidated on review/admin writes)
-# CACHE_USER_CTX_TTL_SECONDS=30     # authenticated login context (invalidated on logout/account delete)
+#
+# Public snapshots stay FRESH for the TTL below, then remain servable as STALE
+# (returned immediately while one owner refreshes in the background) for
+# CACHE_STALE_TTL_SECONDS, so an origin/database failure keeps serving the last
+# known good value instead of failing every request. Authentication-context
+# entries are never served stale.
+# CACHE_HOMEPAGE_TTL_SECONDS=300
+# CACHE_SEARCH_TTL_SECONDS=300
+# CACHE_ASSET_TTL_SECONDS=300        # asset detail page (reviews + rating; invalidated on review/admin writes)
+# CACHE_USER_CTX_TTL_SECONDS=30      # authenticated login context (invalidated on logout/account delete; never stale)
+# CACHE_STALE_TTL_SECONDS=86400      # how long stale public values stay servable (24h default)
+#
+# Per-worker in-memory L1 cache (bounded, survives a Dragonfly outage). Budgets
+# are per process, so cluster memory = workers x L1 budget.
+# CACHE_L1_BYTES=33554432            # 32 MiB per worker
+# CACHE_L1_MAX_ENTRIES=2000
+# CACHE_COALESCE_WAIT_MS=3000        # how long a follower waits for another worker's cold fill before loading itself
+# RELEASE_ID=                        # stable static cache-buster shared by every worker (auto-derived from the bundle if unset)
 
 # --- Cluster / concurrency / pooling tuning (optional) ---
 # Node cluster mode: the app forks WORKER_COUNT HTTP worker processes (each is
@@ -47,8 +63,17 @@ PROJECT_BASE_URL=https://godotassetlibrary.com
 # MONGO_MIN_POOL=0           # pre-warmed connections kept ready (default 0 = none; pure lazy)
 # MONGO_MAX_IDLE_MS=300000   # close idle connections after this many ms (default 5 min)
 # TELEMETRY_LOG_INTERVAL_MS=60000  # how often to log a telemetry snapshot (ms; default 60s)
+# TELEMETRY_AGGREGATE_INTERVAL_MS=10000  # how often workers ship their snapshot to the primary for the cluster /metrics view (default 10s)
 # METRICS_TOKEN=             # optional bearer token protecting GET /metrics (leave blank to keep it open)
 # ARGON2_MAX_CONCURRENCY=2
+
+# --- HTTP server lifecycle (tunable socket/session timeouts) ---
+# HTTP_REQUEST_TIMEOUT_MS=60000      # hard deadline for receiving the request body
+# HTTP_HEADERS_TIMEOUT_MS=60000      # deadline for the full request headers
+# HTTP_KEEPALIVE_TIMEOUT_MS=5000     # how long an idle keep-alive connection stays open
+# HTTP_MAX_REQUESTS_PER_SOCKET=1000  # max requests served on one keep-alive socket
+# WORKER_DRAIN_TIMEOUT_MS=10000      # worker graceful-shutdown drain deadline
+# PRIMARY_DRAIN_TIMEOUT_MS=15000     # primary waits this long for workers to drain before exiting
 
 # Import window (comma separated Godot versions the mirror imports)
 # IMPORT_GODOT_VERSIONS=2.2,3.9,4.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:18-alpine
+# --- Builder stage: native deps (argon2) + webpack/template/SCSS build ---
+FROM node:18-alpine AS builder
 
 WORKDIR /app
 
@@ -9,11 +10,29 @@ RUN apk add --no-cache python3 make g++ \
 	&& npm ci
 
 COPY . .
-RUN npm run build
 
-# Express enables its compiled view cache in production. Set this only after
-# the build so npm ci still installs TypeScript/Webpack dev dependencies.
+# Build, then drop dev-only packages so the runtime image is slim. The build
+# must run before pruning because it needs TypeScript/Webpack/Sass.
+RUN npm run build \
+	&& npm prune --omit=dev
+
+# --- Runtime stage: minimal, non-root ---
+FROM node:18-alpine
+
 ENV NODE_ENV=production
+WORKDIR /app
+
+# Only the compiled app and its production dependencies; the native argon2
+# binary was compiled in the builder against the same Alpine base.
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+
+# Run as an unprivileged user. Sitemap generation writes
+# dist/public/sitemap.xml at runtime, so that directory stays writable.
+RUN mkdir -p /app/dist/public \
+	&& chown -R node:node /app
+
+USER node
 
 EXPOSE 3000
 

--- a/README.md
+++ b/README.md
@@ -58,12 +58,44 @@ Migrations create/verify:
 * `0002` — backfills the confidence-adjusted `rating_score` (95% Wilson lower bound) used by "Highest rated" sorting.
 * `0003` — backfills the normalized `modify_date_at` used by "Recently updated" sorting.
 * `0004` — deduplicates reviews by `(user_id, asset_id)` and creates the unique index.
+* `0005` — backfills the numeric `godot_major` used by major-line browsing filters.
+* `0006` — backfills the denormalized `is_public` flag used by the public-catalog filter (the importer keeps it current afterwards).
 
 Operational maintenance (run against a snapshot first):
 ```
 npm run reconcile:ratings   # Recompute vote counters + rating_score from reviews
 npm run audit:catalog       # Read-only catalog health audit
+npm run audit:queries       # explain("executionStats") baseline for the hot query shapes (capture before/after index changes)
 ```
+
+Load / failure testing (against a running instance):
+```
+npm run loadtest -- --url http://localhost:8080 --paths '/,/search/' --concurrency 50 --duration 15
+# Warm hits, cold unique paths, and random-abuse-URL profiles all use the same harness.
+```
+
+### Monitoring & runbook
+`GET /metrics` (bearer-protected via `METRICS_TOKEN`) exposes Prometheus text.
+Per-process metrics are available immediately; a cluster-wide block
+(`http_cluster_*`) is aggregated by the primary over IPC and appears on every
+worker within a few seconds (`TELEMETRY_AGGREGATE_INTERVAL_MS`, default 10s).
+Route-class metrics (`http_requests_{homepage,browse,search,asset,...}_total`)
+let you tell crawler-vs-bot-vs-user load apart without high-cardinality labels.
+
+Suggested alert thresholds (per worker unless noted):
+- `http_request_duration_p99_ms` > 2000ms sustained — origin slowing under load.
+- `http_event_loop_lag_max_ms` climbing (or > 500ms) — CPU-bound blocking.
+- `mongo_wait_queue_timeouts_total` / `mongo_server_selection_errors_total` rising — MongoDB saturated; expected when uncached overload is allowed to run into fail-fast timeouts.
+- `http_5xx_total` rate rising — upstream errors; check Mongo + cache error counters.
+- `cache_stale_hits_total` rising — public snapshots being served stale; expected and healthy during origin/dependency trouble, worth watching if sustained.
+- `http_static_requests_total` vs `http_requests_total` — the static/dynamic split; a large static share means the edge/CDN is absorbing traffic.
+
+Failure drills to run before relying on edge caching:
+1. Stop Dragonfly while serving warm traffic → expect stale/L1 serving, no Mongo stampede.
+2. Stop MongoDB while stale snapshots exist → expect stale public pages, no cached 4xx/5xx.
+3. Restart one worker during load → auto-heal + graceful drain, no dropped requests.
+4. Deploy while requests are active → readiness drops, connections drain, no 503s.
+5. Confirm authenticated/mutation traffic never receives cached anonymous HTML.
 
 ## Folder Structure
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     image: nodejs
     container_name: gda_nodejs
     restart: always
+    init: true
+    stop_grace_period: 25s
     env_file: .env
     environment:
       - NODE_ENV=production
@@ -21,13 +23,21 @@ services:
       - DRAGONFLY_URL=redis://dragonfly:6379
     depends_on:
       db:
-        condition: service_started
-      dragonfly:
         condition: service_healthy
+      # Dragonfly is an optimization, never a hard dependency: the application
+      # is fail-open, so only require the container to have started, not to be
+      # healthy. A cache outage must not block the origin from serving.
+      dragonfly:
+        condition: service_started
     ports:
       - "8080:3000"
     networks:
       - app-network
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/health"]
       interval: 30s
@@ -41,7 +51,7 @@ services:
     restart: unless-stopped
     command:
       - --cache_mode=true
-      - --maxmemory=512mb
+      - --maxmemory=1gb
       - --proactor_threads=1
       - --primary_port_http_enabled=false
       - --version_check=false
@@ -72,6 +82,12 @@ services:
       - dbdata:/data/db
     networks:
       - app-network
+    healthcheck:
+      test: ["CMD", "mongo", "--quiet", "--eval", "db.adminCommand({ ping: 1 }).ok"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
 
 networks:
   app-network:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "godot-asset-library",
       "version": "1.0.0",
       "dependencies": {
+        "@overnightjs/core": "^1.7.6",
         "adm-zip": "^0.5.9",
         "argon2": "^0.27.2",
         "body-parser": "^1.19.1",
@@ -57,7 +58,6 @@
         "winston": "^3.4.0"
       },
       "devDependencies": {
-        "@overnightjs/core": "^1.7.6",
         "@types/adm-zip": "^0.5.0",
         "@types/compression": "^1.7.2",
         "@types/cookie-parser": "^1.4.2",
@@ -73,6 +73,9 @@
         "@types/pubsub-js": "^1.8.3",
         "@typescript-eslint/eslint-plugin": "^4.0.1",
         "@typescript-eslint/parser": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@aws-sdk/core": {
@@ -699,7 +702,6 @@
       "version": "1.7.6",
       "resolved": "https://registry.npmjs.org/@overnightjs/core/-/core-1.7.6.tgz",
       "integrity": "sha512-2MeVIG8MTLKAqLQKm7UvwDmMchhHka9A36o2PxjT0ES4wHm2lg6RkClRDrsavGU6LmHsx6WDQfVC11/aXZQjkQ==",
-      "dev": true,
       "dependencies": {
         "express": "^4.16.3",
         "reflect-metadata": "^0.1.13",
@@ -6163,8 +6165,7 @@
     "node_modules/reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
-      "dev": true
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.1",
@@ -7651,7 +7652,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/tsutils": {
@@ -8779,7 +8779,6 @@
       "version": "1.7.6",
       "resolved": "https://registry.npmjs.org/@overnightjs/core/-/core-1.7.6.tgz",
       "integrity": "sha512-2MeVIG8MTLKAqLQKm7UvwDmMchhHka9A36o2PxjT0ES4wHm2lg6RkClRDrsavGU6LmHsx6WDQfVC11/aXZQjkQ==",
-      "dev": true,
       "requires": {
         "express": "^4.16.3",
         "reflect-metadata": "^0.1.13",
@@ -12854,8 +12853,7 @@
     "reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
-      "dev": true
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "regexp.prototype.flags": {
       "version": "1.4.1",
@@ -13912,8 +13910,7 @@
     "tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "1.0.0",
   "description": "An Open Source (AGPLv3) Godot Asset Library",
   "main": "none",
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
+    "@overnightjs/core": "^1.7.6",
     "adm-zip": "^0.5.9",
     "argon2": "^0.27.2",
     "body-parser": "^1.19.1",
@@ -53,7 +57,6 @@
     "winston": "^3.4.0"
   },
   "devDependencies": {
-    "@overnightjs/core": "^1.7.6",
     "@types/adm-zip": "^0.5.0",
     "@types/compression": "^1.7.2",
     "@types/cookie-parser": "^1.4.2",
@@ -78,6 +81,8 @@
     "lint:check": "eslint . --ext .js,.ts",
     "typecheck": "tsc --noEmit",
     "audit:catalog": "ts-node --transpile-only -r tsconfig-paths/register src/core/maintenance/runCatalogAudit.ts",
+    "audit:queries": "ts-node --transpile-only -r tsconfig-paths/register src/core/maintenance/runQueryAudit.ts",
+    "loadtest": "node scripts/loadtest.js",
     "reconcile:ratings": "ts-node --transpile-only -r tsconfig-paths/register src/core/maintenance/runReconcileRatings.ts",
     "migrate": "ts-node --transpile-only -r tsconfig-paths/register src/core/migrations/runMigrations.ts",
     "test:build": "tsc -p tsconfig.test.json",

--- a/scripts/loadtest.js
+++ b/scripts/loadtest.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Minimal, dependency-free origin load harness for Phase 7 capacity drills.
+ *
+ * Usage:
+ *   node scripts/loadtest.js \
+ *     --url http://localhost:8080 \
+ *     --paths '/,/search/,/asset/abc-123' \
+ *     --concurrency 50 \
+ *     --duration 15
+ *
+ * Fires random-path GETs from `concurrency` parallel workers for `duration`
+ * seconds, then prints throughput, latency percentiles and the status
+ * distribution. Run warm (repeat paths), cold (unique paths) and abuse
+ * (random high-cardinality paths) profiles against one worker first, then the
+ * configured cluster.
+ */
+const http = require('http')
+const https = require('https')
+
+function parseArg (name, fallback) {
+  const index = process.argv.indexOf(`--${name}`)
+  if (index === -1 || process.argv[index + 1] === undefined) return fallback
+  return process.argv[index + 1]
+}
+
+const baseUrl = parseArg('url', 'http://localhost:8080')
+const paths = parseArg('paths', '/').split(',').filter(Boolean).map(p => p.trim())
+const concurrency = Number.parseInt(parseArg('concurrency', '20'), 10)
+const durationSec = Number.parseInt(parseArg('duration', '10'), 10)
+const url = new URL(baseUrl)
+
+const transport = url.protocol === 'https:' ? https : http
+const latencies = []
+const statusCounts = new Map()
+let completed = 0
+let errors = 0
+const start = Date.now()
+
+function request (workerId) {
+  const path = paths[Math.floor(Math.random() * paths.length)]
+  const reqStart = Date.now()
+  const req = transport.get({
+    hostname: url.hostname,
+    port: url.port,
+    path,
+    headers: { 'user-agent': 'godot-loadtest' }
+  }, (res) => {
+    res.resume()
+    res.on('end', () => {
+      completed++
+      latencies.push(Date.now() - reqStart)
+      statusCounts.set(res.statusCode, (statusCounts.get(res.statusCode) ?? 0) + 1)
+      next(workerId)
+    })
+  })
+  req.on('error', () => {
+    errors++
+    completed++
+    next(workerId)
+  })
+}
+
+function next (workerId) {
+  if (Date.now() - start >= durationSec * 1000) return
+  request(workerId)
+}
+
+// Start the workers.
+for (let i = 0; i < concurrency; i++) request(i)
+
+// Wait for the window, then report.
+setTimeout(() => {
+  const elapsedSec = (Date.now() - start) / 1000
+  const sorted = [...latencies].sort((a, b) => a - b)
+  const pct = (p) => sorted.length > 0 ? sorted[Math.min(sorted.length - 1, Math.floor(p * sorted.length))] : 0
+  const total = completed
+  const rps = total / elapsedSec
+  console.log('--- loadtest results ---')
+  console.log(`target: ${baseUrl}  paths: [${paths.join(', ')}]`)
+  console.log(`concurrency: ${concurrency}  duration: ${durationSec}s`)
+  console.log(`completed: ${total}  errors: ${errors}  elapsed: ${elapsedSec.toFixed(1)}s  rps: ${rps.toFixed(1)}`)
+  console.log(`latency p50: ${pct(0.5)}ms  p95: ${pct(0.95)}ms  p99: ${pct(0.99)}ms  max: ${pct(1)}ms`)
+  console.log(`status: ${JSON.stringify(Object.fromEntries(statusCounts))}`)
+  process.exit(0)
+}, durationSec * 1000 + 500)

--- a/src/app/code/admin/services/AdminService.ts
+++ b/src/app/code/admin/services/AdminService.ts
@@ -13,7 +13,7 @@ import { UpdatePromobarMessage } from '../models/UPDATE/UpdatePromobarMessage'
 import { UpdateSiteRestrictions } from '../models/UPDATE/UpdateSiteRestrictions'
 import { UpdateSiteFiles } from '../models/UPDATE/UpdateSiteFiles'
 import { invalidateSiteFileCache } from 'core/utils/siteFiles'
-import { buildAllAssetCacheKeys, cacheDelete } from 'core/utils/dragonfly'
+import { invalidateAssetCache } from 'core/utils/dragonfly'
 import { GetReviewsByIdList } from '../models/GET/GetReviewsByIdList'
 import { UpdateReportIgnoreById } from '../models/UPDATE/UpdateReportIgnoreById'
 import { GetReportById } from '../models/GET/GetReportById'
@@ -163,8 +163,9 @@ export class AdminService {
     await UpdateReportApproveById(reportId)
     await DeleteReviewById(reportInfo.review_id)
     // The deleted review and adjusted counters are cached on the public asset
-    // page; drop every major variant so the moderation is reflected immediately.
-    void cacheDelete(...buildAllAssetCacheKeys(reviewInfo.asset_id))
+    // page; invalidate every major variant (and bump the asset epoch to fence
+    // any in-flight loader) so the moderation is reflected immediately.
+    await invalidateAssetCache(reviewInfo.asset_id)
     res.send()
   }
 

--- a/src/app/code/asset/controllers/AssetController.ts
+++ b/src/app/code/asset/controllers/AssetController.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Middleware, Post, Patch } from '@overnightjs/core'
-import { Request, Response } from 'express'
+import { NextFunction, Request, Response } from 'express'
 import { StatusCodes } from 'http-status-codes'
 import rateLimit from 'express-rate-limit'
 import { CheckIfUserExistAndSendError } from 'core/modules/authentication/middleware/CheckIfUserExistAndSendError'
@@ -46,8 +46,8 @@ export class AssetController {
    */
   @Get(':id/*')
   @Middleware(renderAssetRateLimit)
-  private async index (req: Request, res: Response): Promise<void> {
-    return await this.AssetService.render(req, res)
+  private async index (req: Request, res: Response, next: NextFunction): Promise<void> {
+    return await this.AssetService.render(req, res, next)
   }
 
   /**
@@ -69,6 +69,8 @@ export class AssetController {
 
     const assetInfo = await GetAssetDisplayInformation(assetId)
     if (assetInfo === null) {
+      res.set('Cache-Control', 'no-store')
+      res.set('X-Robots-Tag', 'noindex, nofollow')
       return res.status(StatusCodes.NOT_FOUND).render('templates/pages/lost/not-found', {
         pageBanner: {
           title: 'Asset not found',

--- a/src/app/code/asset/models/GET/GetRelatedAssets.ts
+++ b/src/app/code/asset/models/GET/GetRelatedAssets.ts
@@ -12,12 +12,16 @@ interface ReturnedAssets extends WithId<Document>, assetGridSchema {}
  * asset: exact Godot version first, then same major version, then same type,
  * then by confidence-adjusted rating and recency.
  *
+ * `categoryLowercase` is the canonical lowercase category key
+ * (`category_lowercase`), so the query matches the indexed field used by every
+ * other discovery query instead of the display-case `category`.
+ *
  * When a major pin is active (the caller passes `major`), the pool is strictly
  * constrained to that major line before ranking, so related cards never show
  * assets from another engine generation.
  */
 export async function GetRelatedAssets (
-  category: string,
+  categoryLowercase: string,
   godotVersion: string | undefined,
   assetType: string | undefined,
   excludeAssetId: string,
@@ -30,7 +34,7 @@ export async function GetRelatedAssets (
       ...PUBLIC_ASSET_FILTER,
       ...godotMajorFilter(major),
       asset_id: { $ne: excludeAssetId },
-      category: category
+      category_lowercase: categoryLowercase
     },
     {
       limit: 12,

--- a/src/app/code/asset/services/AssetService.ts
+++ b/src/app/code/asset/services/AssetService.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express'
+import { NextFunction, Request, Response } from 'express'
 import { StatusCodes } from 'http-status-codes'
 import { logger } from 'core/utils/logger'
 import { GetAssetDisplayInformation } from '../models/GET/GetAssetDisplayInformation'
@@ -33,7 +33,7 @@ import { buildAssetUrl } from 'core/utils/assetUrl'
 import { buildCategoryPath } from 'core/utils/taxonomyUrl'
 import { BadRequestError } from 'core/utils/httpError'
 import { attachCardExtras } from 'core/utils/cardView'
-import { buildAllAssetCacheKeys, buildAssetCacheKey, cacheDelete, cacheGetOrLoad } from 'core/utils/dragonfly'
+import { buildAssetCacheKey, cacheGetOrLoad, getAssetEpoch, invalidateAssetCache } from 'core/utils/dragonfly'
 import { GODOT_VERSION_PREFERENCE_COOKIE } from 'core/utils/godotVersionPreference'
 import { resolveBrowsingMajor } from 'core/utils/godotMajorAvailability'
 
@@ -42,7 +42,7 @@ const REVIEWS_PER_PAGE = 10
 const parsedAssetTtl = Number.parseInt(process.env.CACHE_ASSET_TTL_SECONDS ?? '', 10)
 const ASSET_CACHE_TTL_SECONDS = Number.isFinite(parsedAssetTtl) && parsedAssetTtl > 0
   ? parsedAssetTtl
-  : 30
+  : 300
 
 interface AssetPageData {
   assetInfo: Awaited<ReturnType<typeof GetAssetDisplayInformation>>
@@ -61,7 +61,7 @@ interface AssetPageData {
  * `major` is the visitor's pinned Godot major and constrains the related-asset
  * cards bundled into the cached page.
  */
-async function loadAssetPageData (assetId: string, reviewsPage = 0, major?: number): Promise<AssetPageData> {
+async function loadAssetPageData (assetId: string, reviewsPage = 0, major?: number, strict = false): Promise<AssetPageData> {
   const assetInfo = await GetAssetDisplayInformation(assetId)
 
   if (assetInfo === null) {
@@ -79,8 +79,23 @@ async function loadAssetPageData (assetId: string, reviewsPage = 0, major?: numb
   const [commentsResult, reviewCountResult, relatedAssetsResult] = await Promise.allSettled([
     GetAssetReviewsById(assetId, REVIEWS_PER_PAGE, reviewsPage * REVIEWS_PER_PAGE),
     GetAssetReviewCount(assetId),
-    GetRelatedAssets(assetInfo.category, assetInfo.godot_version, assetInfo.type, assetInfo.asset_id, major)
+    GetRelatedAssets(
+      assetInfo.category_lowercase ?? String(assetInfo.category ?? '').toLowerCase(),
+      assetInfo.godot_version,
+      assetInfo.type,
+      assetInfo.asset_id,
+      major
+    )
   ])
+
+  // A cached snapshot must be complete: never write a partial page to the
+  // cache as "fresh". The stale-capable cache serves the previous complete
+  // snapshot on refresh failure instead; a cold start surfaces the error.
+  if (strict && (commentsResult.status === 'rejected' ||
+      reviewCountResult.status === 'rejected' ||
+      relatedAssetsResult.status === 'rejected')) {
+    throw new Error('Refusing to cache an incomplete asset page')
+  }
 
   return {
     assetInfo,
@@ -100,7 +115,7 @@ export class AssetService {
    * @param {Response} res
    * @returns
    */
-  public async render (req: Request, res: Response): Promise<any> {
+  public async render (req: Request, res: Response, next: NextFunction): Promise<any> {
     const assetId = striptags(req.params.id ?? '')
     const authToken = striptags(req.cookies['auth-token'] ?? '')
 
@@ -137,8 +152,9 @@ export class AssetService {
         const cached = await cacheGetOrLoad<AssetPageData>(
           buildAssetCacheKey(assetId, relatedMajor),
           ASSET_CACHE_TTL_SECONDS,
-          async () => await loadAssetPageData(assetId, 0, relatedMajor),
-          10_000
+          async () => await loadAssetPageData(assetId, 0, relatedMajor, true),
+          10_000,
+          { epoch: async () => await getAssetEpoch(assetId) }
         )
         // Defensive clone so per-request mutations (saved state, card extras,
         // readme render) never leak into the shared cache entry.
@@ -146,11 +162,13 @@ export class AssetService {
       } else {
         // Paginated or authenticated views bypass the cache and must load the
         // requested reviews page (the cached bundle is always page 0).
-        bundle = await loadAssetPageData(assetId, reviewsPage, relatedMajor)
+        bundle = await loadAssetPageData(assetId, reviewsPage, relatedMajor, false)
       }
       const { assetInfo, comments, reviewCount, relatedAssets } = bundle
 
       if (assetInfo === null) {
+        res.set('Cache-Control', 'no-store')
+        res.set('X-Robots-Tag', 'noindex, nofollow')
         return res.status(StatusCodes.NOT_FOUND).render('templates/pages/lost/not-found', {
           pageBanner: {
             title: 'Asset not found',
@@ -256,12 +274,10 @@ export class AssetService {
       })
     } catch (e: any) {
       logger.log('error', `Failed to load asset page: ${assetId}, ${e?.message}`, [e])
-      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).render('templates/pages/lost/server-error', {
-        pageBanner: {
-          title: 'Something went wrong',
-          info: 'Sorry, we\'re having issues loading this page right now'
-        }
-      })
+      // Forward to the central error middleware so the response gets a
+      // no-store/noindex policy and MongoDB errors are classified for
+      // telemetry, instead of rendering directly and keeping a public header.
+      return next(e)
     }
   }
 
@@ -365,9 +381,10 @@ export class AssetService {
     // the confidence-adjusted rating_score always match what cards display.
     await RefreshAssetRating(assetId)
 
-    // The public asset page is cached briefly; drop every major variant so the
-    // review and its rating change are reflected immediately.
-    void cacheDelete(...buildAllAssetCacheKeys(assetId))
+    // The public asset page is cached briefly; invalidate every major variant
+    // (and bump the asset epoch to fence any in-flight loader) so the review
+    // and its rating change are reflected immediately.
+    await invalidateAssetCache(assetId)
 
     res.send()
   }

--- a/src/app/code/guides/services/GuidesService.ts
+++ b/src/app/code/guides/services/GuidesService.ts
@@ -20,6 +20,8 @@ export class GuidesService {
   public renderGuide (req: Request, res: Response): void {
     const guide = getGuideBySlug(req.params.slug ?? '')
     if (guide === undefined) {
+      res.set('Cache-Control', 'no-store')
+      res.set('X-Robots-Tag', 'noindex, nofollow')
       return res.status(StatusCodes.NOT_FOUND).render('templates/pages/lost/not-found', {
         pageBanner: {
           title: 'Guide not found',

--- a/src/app/code/guides/views/templates/index.eta
+++ b/src/app/code/guides/views/templates/index.eta
@@ -4,7 +4,7 @@
     description: 'Learn how to install Godot assets, use shaders, choose compatible plugins and get more out of the Godot Asset Library with free guides.',
     url: 'https://godotassetlibrary.com/guides',
     moduleName: 'guides',
-    image: 'https://godotassetlibrary.com/images/logo-image.png',
+    image: 'https://godotassetlibrary.com/images/logo-image.png?cache=' + (it?._locals?.buildString ?? ''),
     jsonLd: {
       "@context": "https://schema.org/",
       "@type": "CollectionPage",

--- a/src/app/code/homepage/services/HomepageService.ts
+++ b/src/app/code/homepage/services/HomepageService.ts
@@ -27,15 +27,17 @@ interface HomepageSnapshot {
 const parsedHomepageTtl = Number.parseInt(process.env.CACHE_HOMEPAGE_TTL_SECONDS ?? '', 10)
 const HOMEPAGE_CACHE_TTL_SECONDS = Number.isFinite(parsedHomepageTtl) && parsedHomepageTtl > 0
   ? parsedHomepageTtl
-  : 60
+  : 300
 
 async function loadHomepageSnapshot (major: number | undefined): Promise<HomepageSnapshot> {
-  // Fetch sections concurrently and degrade per-section instead of failing the
-  // whole homepage when one query hiccups. Every listing query is filtered to
-  // the pinned major BEFORE sorting/limiting so each section stays full. The
-  // global denormalized category counts span every imported version, so pinned
-  // views compute version-aware counts from the public catalog instead.
-  const [trending, featured, lastModified, categories] = await Promise.allSettled([
+  // Fetch sections concurrently. Every listing query is filtered to the pinned
+  // major BEFORE sorting/limiting so each section stays full; pinned views
+  // compute version-aware counts from the public catalog instead of the global
+  // denormalized counts. A section failure rejects the whole snapshot so a
+  // partial homepage is never cached as "fresh": the stale-capable cache
+  // serves the previous complete snapshot instead, and a cold start surfaces
+  // the error rather than caching empty sections.
+  const [trending, featured, lastModified, categories] = await Promise.all([
     GetTrendingAssets(major),
     GetFourAssetsForHomepage(major),
     GetLastModifiedAssets(major),
@@ -45,10 +47,10 @@ async function loadHomepageSnapshot (major: number | undefined): Promise<Homepag
   ])
 
   return {
-    trendingAssets: trending.status === 'fulfilled' ? trending.value : [],
-    featuredAssets: featured.status === 'fulfilled' ? featured.value : [],
-    lastModifiedAssets: lastModified.status === 'fulfilled' ? lastModified.value : [],
-    categoriesObject: categories.status === 'fulfilled' ? categories.value : {}
+    trendingAssets: trending,
+    featuredAssets: featured,
+    lastModifiedAssets: lastModified,
+    categoriesObject: categories
   }
 }
 

--- a/src/app/code/homepage/views/templates/index.eta
+++ b/src/app/code/homepage/views/templates/index.eta
@@ -3,7 +3,7 @@
   description: 'Kickstart your development with the best FREE Godot assets for your next game or project',
   url: 'https://godotassetlibrary.com',
   moduleName: 'homepage',
-  image: 'https://godotassetlibrary.com/images/logo-image.png'
+  image: 'https://godotassetlibrary.com/images/logo-image.png?cache=' + (it?._locals?.buildString ?? '')
 } %>
 <% layout('templates/components/layouts/promobar-nav-body-footer/promobar-nav-body-footer.eta') %>
 

--- a/src/app/code/search/models/GET/GetSearchFacets.ts
+++ b/src/app/code/search/models/GET/GetSearchFacets.ts
@@ -85,22 +85,23 @@ function buildFacets (output: Record<string, any[]>): SearchFacets {
  * Disjunctive (self-excluding) facets, consolidated to cut Mongo fan-out.
  *
  * Each facet omits only its own dimension so counts stay self-excluding (a
- * selected category does not collapse the category facet). Three shapes, in
- * order of preference, to minimise round trips:
+ * selected category does not collapse the category facet). Two shapes, in
+ * order of preference:
  *
  * 1. No dimension filter selected (categories/engines/types/supports all
  *    empty) -> every facet filter is identical, so ONE outer `$match` (which
- *    keeps `$text` legal as the first stage) feeds four `$group`
- *    sub-pipelines in a single `$facet`.
- * 2. Browsing (no `$text`) with filters selected -> the self-excluding
- *    `$match` can live inside each `$facet` sub-pipeline, so all four facets
- *    still run in one aggregation.
- * 3. Text search with filters selected -> `$text` cannot appear inside `$facet`
- *    sub-pipelines (it must be the first stage of its own pipeline), so each
- *    facet runs as a separate aggregation.
+ *    keeps `$text` legal as the first stage and CAN use an index) feeds four
+ *    `$group` sub-pipelines in a single `$facet`.
+ * 2. Filters selected -> each facet runs as its OWN `$match`-first
+ *    aggregation (in parallel). A first-stage `$facet` cannot use an index:
+ *    it feeds the ENTIRE collection to every sub-pipeline in memory, so every
+ *    filtered page would scan the whole collection. Separate `$match`-first
+ *    pipelines keep every facet indexable. This also covers text search,
+ *    where `$text` must be the first stage and cannot appear inside a `$facet`
+ *    sub-pipeline at all.
  *
- * Result: 4 aggregations -> 1 for browse and for plain text searches (the
- * common crawl/user paths), staying at 4 only for search + selected filters.
+ * Result: 4 aggregations -> 1 for un-filtered browse/text (the common crawl
+ * and user paths), staying at 4 only for filtered views.
  */
 export async function GetSearchFacets (
   query: string,
@@ -112,7 +113,7 @@ export async function GetSearchFacets (
   const hasDimensionFilters = DIMENSION_KEYS.some(dim => (options[dim] ?? []).length > 0)
 
   if (!hasDimensionFilters) {
-    // Strategy 1: all four facet filters are identical, so share one $match.
+    // All four facet filters are identical, so share one $match.
     const filter = buildSearchFilter(query, options)
     const facetStages: Record<string, any[]> = {}
     for (const spec of FACET_SPECS) {
@@ -125,29 +126,14 @@ export async function GetSearchFacets (
     return buildFacets(doc ?? {})
   }
 
-  if (query === '') {
-    // Strategy 2: browse with filters; each sub-pipeline has its own $match.
-    const facetStages: Record<string, any[]> = {}
-    for (const spec of FACET_SPECS) {
-      facetStages[spec.key] = [
-        { $match: facetFilterFor(query, options, spec.omit) },
-        groupStageFor(spec)
-      ]
-    }
-    const [doc] = await assets.aggregate([
-      { $facet: facetStages }
-    ]).maxTimeMS(5000).toArray()
-    return buildFacets(doc ?? {})
-  }
-
-  // Strategy 3: text search with filters selected -> separate aggregations.
+  // Filters selected: separate $match-first aggregations per facet (see doc
+  // comment above for why a first-stage $facet would scan the whole catalog).
   const results = await Promise.all(FACET_SPECS.map(async spec => {
     const filter = facetFilterFor(query, options, spec.omit)
-    const pipeline: any[] = [
+    return await assets.aggregate([
       { $match: filter },
       groupStageFor(spec)
-    ]
-    return await assets.aggregate(pipeline).maxTimeMS(5000).toArray()
+    ]).maxTimeMS(5000).toArray()
   }))
 
   const doc: Record<string, any[]> = {}

--- a/src/app/code/search/services/SearchService.ts
+++ b/src/app/code/search/services/SearchService.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import crypto from 'crypto'
 import { TokenServices } from 'core/modules/authentication/services/TokenServices'
 import { GetUserSavedAssets } from 'app/code/dashboard/models/GET/GetUserSavedAssets'
 import striptags from 'striptags'
@@ -29,7 +30,7 @@ interface CachedSearchData {
 const parsedSearchTtl = Number.parseInt(process.env.CACHE_SEARCH_TTL_SECONDS ?? '', 10)
 const SEARCH_CACHE_TTL_SECONDS = Number.isFinite(parsedSearchTtl) && parsedSearchTtl > 0
   ? parsedSearchTtl
-  : 60
+  : 300
 
 function searchCacheKey (
   query: string,
@@ -38,9 +39,11 @@ function searchCacheKey (
   sort: string,
   options: SearchFilterOptions
 ): string {
-  // Parsing already deduplicates/caps filters. Sort copies here so equivalent
-  // parameter orderings share one key and cannot inflate cache cardinality.
-  return `gda:v1:search:${Buffer.from(JSON.stringify({
+  // Parsing already deduplicates/caps filters. Normalize to a canonical JSON
+  // payload (equivalent orderings share one key) and hash it to a fixed-size
+  // digest so one-time bot queries can never create oversized keys or balloon
+  // the key space.
+  const canonical = JSON.stringify({
     query,
     limit,
     skip,
@@ -51,7 +54,8 @@ function searchCacheKey (
     supports: [...(options.supports ?? [])].sort(),
     featured: options.featured === true,
     major: godotMajorCacheSuffix(options.godotMajor)
-  })).toString('base64url')}`
+  })
+  return `gda:v2:search:${crypto.createHash('sha256').update(canonical).digest('hex')}`
 }
 
 export class SearchService {
@@ -111,7 +115,7 @@ export class SearchService {
     if (parsed.query !== '' && assets.length === 1) {
       try {
         relatedForSearch = await GetRelatedAssets(
-          assets[0].category,
+          String(assets[0].category ?? '').toLowerCase(),
           assets[0].godot_version,
           assets[0].type,
           assets[0].asset_id,

--- a/src/app/utilities/fetchFromGodot/jobs/fetchFromGodot.ts
+++ b/src/app/utilities/fetchFromGodot/jobs/fetchFromGodot.ts
@@ -140,6 +140,10 @@ function normalizeAssetForSync (asset: any, isNew: boolean): void {
   asset.source_last_seen_at = new Date()
   asset.source_last_synced_at = new Date()
   asset.source_status = 'active'
+  // Denormalized public-catalog flag (migration 0006 + markSourceStatus keep
+  // it current). source_status is 'active' here, so only the upstream
+  // `searchable` flag decides visibility.
+  asset.is_public = asset.searchable !== 'false'
   if (isNew) {
     asset.source_missing_runs = 0
   }
@@ -170,6 +174,17 @@ async function markSourceStatus (seenIDs: Set<string>, syncedAt: Date): Promise<
     }
   )
 
+  // Keep the denormalized is_public flag current for still-listed assets:
+  // active + searchable -> public, active + non-searchable -> hidden.
+  await assets.updateMany(
+    { legacy_asset_id: { $in: seen }, searchable: { $ne: 'false' } },
+    { $set: { is_public: true } }
+  )
+  await assets.updateMany(
+    { legacy_asset_id: { $in: seen }, searchable: 'false' },
+    { $set: { is_public: false } }
+  )
+
   await assets.updateMany(
     { legacy_asset_id: { $nin: seen }, source_status: { $ne: 'unavailable' } },
     { $inc: { source_missing_runs: 1 } }
@@ -177,7 +192,7 @@ async function markSourceStatus (seenIDs: Set<string>, syncedAt: Date): Promise<
 
   await assets.updateMany(
     { legacy_asset_id: { $nin: seen }, source_missing_runs: { $gte: 3 } },
-    { $set: { source_status: 'unavailable' } }
+    { $set: { source_status: 'unavailable', is_public: false } }
   )
 }
 

--- a/src/app/utilities/fetchFromGodot/schema/assets.ts
+++ b/src/app/utilities/fetchFromGodot/schema/assets.ts
@@ -26,6 +26,8 @@ export interface assetSchema {
   'issues_url': string
   'icon_url': string
   'searchable': string
+  /** Denormalized public-catalog flag: `source_status !== 'unavailable' && searchable !== 'false'`. */
+  'is_public'?: boolean
   'modify_date': string
   'added_date': Date
   'download_url': string

--- a/src/core/MongoHelper.ts
+++ b/src/core/MongoHelper.ts
@@ -1,6 +1,7 @@
 import { MongoClient, Db } from 'mongodb'
+import cluster from 'cluster'
 import { logger } from 'core/utils/logger'
-import { getDefaultMongoPool } from 'core/utils/clusterConfig'
+import { getDefaultMongoPool, getPrimaryMongoPool } from 'core/utils/clusterConfig'
 
 export class MongoHelper {
   private static instance: MongoHelper
@@ -68,7 +69,11 @@ export class MongoHelper {
       // MONGO_MAX_IDLE_MS, so steady state stays low. The 5s wait-queue
       // timeout stays as a fail-fast backstop for genuine overload.
       const parsedMax = Number.parseInt(process.env.MONGO_MAX_POOL ?? '', 10)
-      const maxPoolSize = Number.isFinite(parsedMax) && parsedMax > 0 ? parsedMax : getDefaultMongoPool()
+      // The primary only runs bootstrap + cron, so it gets a smaller pool and
+      // leaves more of the total budget to the workers that serve traffic.
+      const maxPoolSize = Number.isFinite(parsedMax) && parsedMax > 0
+        ? parsedMax
+        : (cluster.isPrimary ? getPrimaryMongoPool() : getDefaultMongoPool())
 
       // 0 = no pre-warmed connections; each one is established on first use.
       const parsedMin = Number.parseInt(process.env.MONGO_MIN_POOL ?? '', 10)

--- a/src/core/RouterServer.ts
+++ b/src/core/RouterServer.ts
@@ -1,6 +1,7 @@
 import * as controllers from 'core/controllers.index'
 import { Server } from '@overnightjs/core'
 import express, { NextFunction, Request, Response } from 'express'
+import { Server as HttpServer } from 'http'
 import { logger } from 'core/utils/logger'
 import compression from 'compression'
 import path from 'path'
@@ -10,6 +11,8 @@ import { GetUserContextByToken } from 'core/modules/authentication/models/user/G
 import { GetPromobarMessage } from 'app/code/admin/models/GET/GetPromobarMesasge'
 import { StatusCodes } from 'http-status-codes'
 import { getSiteFileContent } from 'core/utils/siteFiles'
+import { classifyCacheControl } from 'core/utils/httpCachePolicy'
+import { getReleaseId } from 'core/utils/releaseId'
 import { generateProxyUrl } from 'core/utils/generateProxyUrl'
 import { buildAssetUrl, buildAssetUrlWithReturn } from 'core/utils/assetUrl'
 import { buildCategoryPath, buildEnginePath } from 'core/utils/taxonomyUrl'
@@ -21,6 +24,7 @@ import {
   normalizeGodotVersionPreference
 } from 'core/utils/godotVersionPreference'
 import * as telemetry from 'core/utils/telemetry'
+import { classifyRouteClass } from 'core/utils/routeClass'
 require('express-async-errors')
 
 let promoCachedMessage: string | null = null
@@ -30,6 +34,12 @@ const PROMO_TTL_MS = 60_000
 
 const parsedTelemetryInterval = Number.parseInt(process.env.TELEMETRY_LOG_INTERVAL_MS ?? '', 10)
 const TELEMETRY_LOG_INTERVAL_MS = Number.isFinite(parsedTelemetryInterval) && parsedTelemetryInterval > 0 ? parsedTelemetryInterval : 60_000
+
+/** Read a positive integer from an env var, falling back when unset/invalid. */
+function parsePositiveIntEnv (name: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[name] ?? '', 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
 
 function refreshPromoMessage (): void {
   if (promoRefresh !== null) {
@@ -78,21 +88,29 @@ class RouterServer extends Server {
   constructor () {
     super(true)
 
-    const buildString = new Date().getTime().toString()
+    // Deployment-wide release id shared by every worker and refork, so static
+    // cache busters (?cache=<id>) converge instead of differing per worker.
+    const buildString = getReleaseId()
 
     this.app.disable('x-powered-by')
     this.app.set('view engine', 'eta')
     this.app.set('views', path.join(__dirname, '/'))
     this.app.set('trust proxy', 1)
     this.app.use(compression())
-    // Static assets are cache-busted with ?cache=<buildString>, so a long
-    // max-age is safe: after a redeploy the new HTML references a new URL.
-    // Non-asset files (robots.txt, sitemap.xml) stay short-lived.
+    // Static assets are cache-busted with ?cache=<buildString> (a stable,
+    // deployment-wide id), so a one-year immutable policy is safe: after a
+    // redeploy the new HTML references a new URL and old entries are simply
+    // never requested again. Mutable text files (robots.txt, sitemap.xml) stay
+    // short-lived.
     this.app.use(express.static(path.join(__dirname, 'public'), {
-      maxAge: '30d',
       setHeaders: (res: Response, filePath: string) => {
+        // Count every static file actually served so /metrics can separate
+        // static (disk/cache) traffic from dynamic SSR traffic.
+        telemetry.recordStaticRequest()
         if (/\.(html?|xml|txt|json)$/.test(filePath)) {
           res.setHeader('Cache-Control', 'public, max-age=300')
+        } else {
+          res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
         }
       }
     }))
@@ -165,19 +183,21 @@ class RouterServer extends Server {
     })
 
     // Track every dynamic request for telemetry (active/peak gauges plus
-    // duration/status stats) without rejecting anything. There is deliberately
-    // no in-flight request cap: cached reads are cheap, and uncached work
-    // either completes or trips MongoDB's fail-fast timeouts and surfaces as a
-    // real error instead of a synthetic 503. Watch http_active_requests and
-    // http_request_duration_p99_ms on /metrics during bursts.
-    this.app.use((_req: Request, res: Response, next: NextFunction) => {
-      telemetry.requestStart()
+    // duration/status/route-class stats) without rejecting anything. There is
+    // deliberately no in-flight request cap: cached reads are cheap, and
+    // uncached work either completes or trips MongoDB's fail-fast timeouts and
+    // surfaces as a real error instead of a synthetic 503. Watch
+    // http_active_requests and http_request_duration_p99_ms on /metrics during
+    // bursts.
+    this.app.use((req: Request, res: Response, next: NextFunction) => {
+      const routeClass = classifyRouteClass(req.method, req.path, req.query)
+      telemetry.requestStart(routeClass)
       let released = false
       const startedAt = Date.now()
       const release = (): void => {
         if (!released) {
           released = true
-          telemetry.requestEnd(Date.now() - startedAt, res.statusCode)
+          telemetry.requestEnd(Date.now() - startedAt, res.statusCode, routeClass)
         }
       }
       res.once('finish', release)
@@ -250,25 +270,20 @@ class RouterServer extends Server {
       next()
     })
 
-    // Public anonymous pages can be cached briefly for crawlers and repeat
-    // visitors; authenticated responses are always revalidated. Never clobber
-    // an existing Cache-Control (e.g. the no-store set above for
-    // /dashboard, /api/, /admin and /register).
-    //
-    // Responses whose HTML varies by the version-preference cookie must stay
-    // private: a shared proxy/CDN must never serve one visitor's 2.x/3.x/All
-    // markup to another. The default (no cookie) is deterministic 4.x and
-    // stays publicly cacheable.
+    // Centralized cache policy (see core/utils/httpCachePolicy.ts). Anonymous
+    // canonical public views get an aggressive shared policy (5-minute s-maxage
+    // + stale-while-revalidate + 24h stale-if-error) so Cloudflare/edge caches
+    // absorb nearly all repeat traffic; authenticated, version-cookie,
+    // arbitrary-query and high-cardinality responses are never shared-cacheable.
+    // Never clobber a Cache-Control set by an earlier middleware (e.g. the
+    // no-store for /dashboard, /api/, /admin and /register above). Handlers that
+    // produce an error/404 override this with no-store themselves.
     this.app.use((req: Request, res: Response, next: NextFunction) => {
-      const versionCookie = req.cookies?.[GODOT_VERSION_PREFERENCE_COOKIE]
-      const hasNonDefaultVersion = versionCookie !== undefined && versionCookie !== ''
-      if (req.method === 'GET' && req.cookies?.['auth-token'] === undefined &&
-          !hasNonDefaultVersion &&
-          res.getHeader('Cache-Control') === undefined) {
-        res.set('Cache-Control', 'public, max-age=120')
-      } else if (req.method === 'GET' && hasNonDefaultVersion &&
-          res.getHeader('Cache-Control') === undefined) {
-        res.set('Cache-Control', 'private, max-age=120')
+      if (res.getHeader('Cache-Control') === undefined) {
+        const decision = classifyCacheControl(req)
+        if (decision !== null) {
+          res.set('Cache-Control', decision)
+        }
       }
       next()
     })
@@ -339,8 +354,9 @@ class RouterServer extends Server {
    * Start the express server
    *
    * @param port {Number} declare the server port
+   * @returns the underlying http.Server so the caller can drain it on shutdown
    */
-  public start (port: number): void {
+  public start (port: number): HttpServer {
     this.app.get('*', (_req: Request, res: Response) => {
       // Unmatched routes are real 404s, not redirects, so crawlers and users
       // see the correct status. The /lost page renders inside the normal shell.
@@ -355,10 +371,43 @@ class RouterServer extends Server {
       })
     })
 
-    this.app.listen(port, () => {
+    const server = this.app.listen(port, () => {
       telemetry.startPeriodicLogging(TELEMETRY_LOG_INTERVAL_MS)
+      telemetry.startEventLoopLagMonitor()
       logger.log('info', `Running on port: ${port}`)
     })
+
+    // Count open keep-alive sockets so overload shows up as socket pressure
+    // before requests queue.
+    telemetry.trackServerSockets(server)
+
+    // Explicit, environment-tunable socket/session timeouts so slow or broken
+    // clients (or a traffic flood) can't pin worker sockets forever. The
+    // defaults reflect the Cloudflare->origin pattern: long-lived keep-alive
+    // connections, bounded requests per socket, and a hard request deadline.
+    // requestTimeout/headersTimeout/maxRequestsPerSocket are newer Node
+    // properties not present in this project's @types/node, hence the cast.
+    const tune = server as HttpServer & {
+      requestTimeout?: number
+      headersTimeout?: number
+      maxRequestsPerSocket?: number
+    }
+    tune.requestTimeout = parsePositiveIntEnv('HTTP_REQUEST_TIMEOUT_MS', 60_000)
+    tune.headersTimeout = parsePositiveIntEnv('HTTP_HEADERS_TIMEOUT_MS', 60_000)
+    tune.maxRequestsPerSocket = parsePositiveIntEnv('HTTP_MAX_REQUESTS_PER_SOCKET', 1000)
+    server.keepAliveTimeout = parsePositiveIntEnv('HTTP_KEEPALIVE_TIMEOUT_MS', 5_000)
+
+    server.on('error', (error: NodeJS.ErrnoException) => {
+      logger.log('error', `HTTP server error: ${error.message}`, [error])
+      // A fatal listen failure (e.g. port already taken after a race) is
+      // unrecoverable: exit so the cluster primary auto-refork is triggered.
+      if (!server.listening && (error.code === 'EADDRINUSE' || error.code === 'EACCES')) {
+        logger.log('error', `Fatal listen error (${error.code}); exiting for cluster refork`)
+        process.exit(1)
+      }
+    })
+
+    return server
   }
 }
 

--- a/src/core/ensureIndexes.ts
+++ b/src/core/ensureIndexes.ts
@@ -1,54 +1,81 @@
+import { Db } from 'mongodb'
 import { MongoHelper } from 'core/MongoHelper'
 import { logger } from 'core/utils/logger'
 import { TEXT_INDEX_NAME } from 'core/migrations/0001-create-text-index'
 
-export async function ensureIndexes (): Promise<void> {
-  try {
-    const db = MongoHelper.getDatabase()
-    const assets = db.collection('assets')
-    const users = db.collection('users')
-    const info = db.collection('info')
+interface IndexOperation {
+  name: string
+  run: () => Promise<unknown>
+}
 
-    const reviews = db.collection('reviews')
-    const reports = db.collection('reports')
+/**
+ * Create/verify the application's MongoDB indexes.
+ *
+ * Each index is attempted INDEPENDENTLY: a failure in one is logged but never
+ * aborts the remaining indexes (matching the migration runner), so a single
+ * bad/conflicting/legacy index can't leave the whole collection missing the
+ * rest of its schema. This function never throws — startup treats it as a
+ * best-effort safety net.
+ *
+ * `dbOverride` is injectable for tests; production callers omit it and the
+ * active MongoHelper database is used.
+ */
+export async function ensureIndexes (dbOverride?: Db): Promise<void> {
+  const db = dbOverride ?? MongoHelper.getDatabase()
+  const assets = db.collection('assets')
+  const users = db.collection('users')
+  const info = db.collection('info')
 
-    // Keep startup memory and pool use predictable. Existing indexes return quickly.
-    const indexOperations: Array<() => Promise<string>> = [
-      async () => await assets.createIndex({ legacy_asset_id: 1 }),
-      async () => await assets.createIndex({ asset_id: 1 }),
-      async () => await assets.createIndex({ category_lowercase: 1 }),
-      async () => await assets.createIndex({ author_lowercase: 1 }),
-      async () => await assets.createIndex({ godot_version: 1 }),
-      async () => await assets.createIndex({ featured: 1 }),
-      async () => await assets.createIndex({ added_date: -1 }),
-      async () => await assets.createIndex({ modify_date: -1 }),
-      async () => await assets.createIndex({ upvotes: -1, godot_version: -1 }),
-      async () => await assets.createIndex({ rating_score: -1, asset_id: 1 }),
-      async () => await assets.createIndex({ modify_date_at: -1, asset_id: 1 }),
-      async () => await assets.createIndex({ godot_major: 1, modify_date_at: -1, asset_id: 1 }),
-      async () => await assets.createIndex({ godot_major: 1, rating_score: -1, upvotes: -1, downvotes: -1, asset_id: 1 }),
-      async () => await assets.createIndex({ category_lowercase: 1, godot_version: 1, rating_score: -1, asset_id: 1 }),
-      async () => await assets.createIndex({ category_lowercase: 1, godot_major: 1, rating_score: -1, asset_id: 1 }),
-      async () => await users.createIndex({ 'resume_tokens.token': 1 }),
-      async () => await users.createIndex({ username: 1 }),
-      async () => await users.createIndex({ username_lowercase: 1 }),
-      async () => await users.createIndex({ human_id: 1 }),
-      async () => await reviews.createIndex({ asset_id: 1 }),
-      async () => await reviews.createIndex({ user_id: 1, asset_id: 1 }),
-      async () => await reviews.createIndex({ asset_id: 1, date: -1 }),
-      async () => await reviews.createIndex({ human_id: 1 }),
-      async () => await reports.createIndex({ type: 1, ignored: 1, approved: 1 }),
-      async () => await reports.createIndex({ human_id: 1 }),
-      async () => await info.createIndex({ type: 1 })
-    ]
+  const reviews = db.collection('reviews')
+  const reports = db.collection('reports')
 
-    for (const createIndex of indexOperations) {
-      await createIndex()
+  // Keep startup memory and pool use predictable. Existing indexes return
+  // quickly, so this is a cheap idempotent check on every boot.
+  const indexOperations: IndexOperation[] = [
+    { name: 'assets.legacy_asset_id', run: async () => await assets.createIndex({ legacy_asset_id: 1 }) },
+    { name: 'assets.asset_id', run: async () => await assets.createIndex({ asset_id: 1 }) },
+    { name: 'assets.category_lowercase', run: async () => await assets.createIndex({ category_lowercase: 1 }) },
+    { name: 'assets.author_lowercase', run: async () => await assets.createIndex({ author_lowercase: 1 }) },
+    { name: 'assets.godot_version', run: async () => await assets.createIndex({ godot_version: 1 }) },
+    { name: 'assets.featured', run: async () => await assets.createIndex({ featured: 1 }) },
+    { name: 'assets.added_date', run: async () => await assets.createIndex({ added_date: -1 }) },
+    { name: 'assets.modify_date', run: async () => await assets.createIndex({ modify_date: -1 }) },
+    { name: 'assets.upvotes_godot_version', run: async () => await assets.createIndex({ upvotes: -1, godot_version: -1 }) },
+    { name: 'assets.rating_score_asset_id', run: async () => await assets.createIndex({ rating_score: -1, asset_id: 1 }) },
+    { name: 'assets.modify_date_at_asset_id', run: async () => await assets.createIndex({ modify_date_at: -1, asset_id: 1 }) },
+    { name: 'assets.godot_major_modify_date_at', run: async () => await assets.createIndex({ godot_major: 1, modify_date_at: -1, asset_id: 1 }) },
+    { name: 'assets.godot_major_rating', run: async () => await assets.createIndex({ godot_major: 1, rating_score: -1, upvotes: -1, downvotes: -1, asset_id: 1 }) },
+    { name: 'assets.category_version_rating', run: async () => await assets.createIndex({ category_lowercase: 1, godot_version: 1, rating_score: -1, asset_id: 1 }) },
+    { name: 'assets.category_major_rating', run: async () => await assets.createIndex({ category_lowercase: 1, godot_major: 1, rating_score: -1, asset_id: 1 }) },
+    { name: 'assets.category_rating_upvotes', run: async () => await assets.createIndex({ category_lowercase: 1, rating_score: -1, upvotes: -1, asset_id: 1 }) },
+    { name: 'users.resume_tokens.token', run: async () => await users.createIndex({ 'resume_tokens.token': 1 }) },
+    { name: 'users.username', run: async () => await users.createIndex({ username: 1 }) },
+    { name: 'users.username_lowercase', run: async () => await users.createIndex({ username_lowercase: 1 }) },
+    { name: 'users.human_id', run: async () => await users.createIndex({ human_id: 1 }) },
+    { name: 'reviews.asset_id', run: async () => await reviews.createIndex({ asset_id: 1 }) },
+    { name: 'reviews.user_id_asset_id', run: async () => await reviews.createIndex({ user_id: 1, asset_id: 1 }) },
+    { name: 'reviews.asset_id_date_id', run: async () => await reviews.createIndex({ asset_id: 1, date: -1, _id: -1 }) },
+    { name: 'reviews.user_id_date_id', run: async () => await reviews.createIndex({ user_id: 1, date: -1, _id: -1 }) },
+    { name: 'reviews.human_id', run: async () => await reviews.createIndex({ human_id: 1 }) },
+    { name: 'reports.type_ignored_approved', run: async () => await reports.createIndex({ type: 1, ignored: 1, approved: 1 }) },
+    { name: 'reports.human_id', run: async () => await reports.createIndex({ human_id: 1 }) },
+    { name: 'info.type', run: async () => await info.createIndex({ type: 1 }) }
+  ]
+
+  const failures: string[] = []
+  for (const operation of indexOperations) {
+    try {
+      await operation.run()
+    } catch (error: any) {
+      failures.push(operation.name)
+      logger.log('warn', `Index ${operation.name} creation failed (continuing with remaining indexes): ${error?.message ?? error}`)
     }
+  }
 
-    // The weighted text index is deployment-managed through `npm run migrate`
-    // because MongoDB only allows one text index per collection. Verify here so
-    // readiness fails clearly instead of surfacing "text index required" at query time.
+  // The weighted text index is deployment-managed through `npm run migrate`
+  // because MongoDB only allows one text index per collection. Verify here so
+  // a missing text index surfaces clearly instead of at query time.
+  try {
     const existingIndexes = await assets.indexes()
     const hasTextIndex = existingIndexes.some(index =>
       index.key !== undefined && Object.values(index.key).some(value => value === 'text')
@@ -58,9 +85,14 @@ export async function ensureIndexes (): Promise<void> {
     } else {
       logger.log('info', `Text index (${TEXT_INDEX_NAME}) verified`)
     }
+  } catch (error: any) {
+    failures.push('assets.text-index-verification')
+    logger.log('warn', `Text index verification failed: ${error?.message ?? error}`)
+  }
 
+  if (failures.length > 0) {
+    logger.log('warn', `Index creation finished with ${failures.length} failure(s): ${failures.join(', ')}`)
+  } else {
     logger.log('info', 'Indexes verified')
-  } catch (e: any) {
-    logger.log('warn', `Index creation failed: ${e?.message ?? e}`, [e])
   }
 }

--- a/src/core/maintenance/queryAudit.ts
+++ b/src/core/maintenance/queryAudit.ts
@@ -1,0 +1,187 @@
+import { Collection, Document } from 'mongodb'
+import { MongoHelper } from 'core/MongoHelper'
+import { logger } from 'core/utils/logger'
+import { buildSearchFilter } from 'app/code/search/models/GET/buildSearchFilter'
+import { PUBLIC_ASSET_FILTER } from 'core/utils/publicCatalog'
+
+/**
+ * Read-only query-shape baseline audit.
+ *
+ * Runs `explain("executionStats")` on the hot discovery/PDP query shapes and
+ * prints, for each: execution time, documents/keys examined, rows returned,
+ * and the winning plan's stage signature (e.g. IXSCAN > SORT vs COLLSCAN).
+ * Capture this BEFORE and AFTER index/query changes so capacity decisions are
+ * driven by measurements, not guesses. It never mutates data. Execute via
+ * `npm run audit:queries`.
+ */
+
+interface WalkedStats {
+  docs: number
+  keys: number
+  returned: number
+  stages: string[]
+}
+
+/** Recursively walk an executionStages tree, summing examined docs/keys. */
+function walkStages (node: any, acc: WalkedStats): void {
+  if (node === null || typeof node !== 'object') return
+  if (typeof node.stage === 'string') acc.stages.push(node.stage)
+  if (typeof node.totalDocsExamined === 'number') acc.docs += Number(node.totalDocsExamined)
+  if (typeof node.totalKeysExamined === 'number') acc.keys += Number(node.totalKeysExamined)
+  if (typeof node.nReturned === 'number') acc.returned = Math.max(acc.returned, node.nReturned)
+  const child = node.inputStage ?? node.inputStages
+  if (child !== undefined && child !== null) {
+    const list = Array.isArray(child) ? child : [child]
+    for (const item of list) walkStages(item, acc)
+  }
+}
+
+function report (label: string, explain: any): void {
+  const stats = explain?.executionStats ?? {}
+  const walked: WalkedStats = { docs: 0, keys: 0, returned: 0, stages: [] }
+  if (stats.executionStages !== undefined) {
+    walkStages(stats.executionStages, walked)
+  } else {
+    walked.docs = stats.totalDocsExamined ?? 0
+    walked.keys = stats.totalKeysExamined ?? 0
+    walked.returned = stats.nReturned ?? 0
+  }
+  const ms = stats.executionTimeMillis ?? 0
+  logger.log('info',
+    `${label.padEnd(44)} ms=${String(ms).padStart(5)} docs=${String(walked.docs).padStart(6)} ` +
+    `keys=${String(walked.keys).padStart(6)} ret=${String(walked.returned).padStart(4)} [${walked.stages.join(' > ')}]`)
+}
+
+async function explainFind (
+  label: string,
+  assets: Collection,
+  filter: Document,
+  options: Document = {}
+): Promise<void> {
+  try {
+    const explain = await assets.find(filter, options).explain('executionStats')
+    report(label, explain)
+  } catch (error: any) {
+    logger.log('warn', `${label}: explain failed: ${error?.message ?? error}`)
+  }
+}
+
+async function explainAggregate (label: string, assets: Collection, pipeline: Document[]): Promise<void> {
+  try {
+    const explain = await assets.aggregate(pipeline).explain('executionStats')
+    report(label, explain)
+  } catch (error: any) {
+    logger.log('warn', `${label}: explain failed: ${error?.message ?? error}`)
+  }
+}
+
+const SEARCH_PROJECTION: Record<string, number> = {
+  category: 1,
+  category_lowercase: 1,
+  godot_version: 1,
+  author: 1,
+  title: 1,
+  quick_description: 1,
+  icon_url: 1,
+  upvotes: 1,
+  downvotes: 1,
+  rating_score: 1,
+  featured: 1,
+  asset_id: 1,
+  previews: 1,
+  card_banner: 1,
+  modify_date: 1,
+  modify_date_at: 1,
+  added_date: 1,
+  version_string: 1,
+  type: 1,
+  support_level: 1,
+  download_url: 1
+}
+
+/** The hot browse/results shape: one $match feeding a results+total $facet. */
+function searchPipeline (filter: Document, sort: Document, skip = 0, limit = 12): Document[] {
+  return [
+    { $match: filter },
+    {
+      $facet: {
+        results: [{ $sort: sort }, { $skip: skip }, { $limit: limit }, { $project: SEARCH_PROJECTION }],
+        total: [{ $count: 'n' }]
+      }
+    }
+  ]
+}
+
+export async function runQueryAudit (): Promise<void> {
+  const db = MongoHelper.getDatabase()
+  const assets = db.collection('assets')
+  const users = db.collection('users')
+
+  // Use real sample values so examined-doc numbers are realistic.
+  const sampleAsset = await assets.findOne(PUBLIC_ASSET_FILTER, {
+    projection: { asset_id: 1, category_lowercase: 1, godot_version: 1, type: 1 }
+  })
+  const sampleAssetId = sampleAsset?.asset_id ?? 'none'
+  const sampleCategory = sampleAsset?.category_lowercase ?? '2d tools'
+  const sampleEngine = sampleAsset?.godot_version ?? '3.4'
+  const sampleType = sampleAsset?.type ?? 'addon'
+  const sampleUser = await users.findOne({}, { projection: { _id: 1 } })
+  const sampleUserId = sampleUser !== null ? String(sampleUser._id) : 'none'
+
+  logger.log('info', '--- Query audit (executionStats) start ---')
+  logger.log('info', `sample: asset=${sampleAssetId} category=${sampleCategory} engine=${sampleEngine} type=${sampleType}`)
+
+  // Homepage shapes.
+  await explainFind('homepage: trending', assets, PUBLIC_ASSET_FILTER,
+    { sort: { rating_score: -1, upvotes: -1, downvotes: -1, asset_id: 1 }, limit: 8 })
+  await explainFind('homepage: featured', assets, { ...PUBLIC_ASSET_FILTER, featured: true },
+    { sort: { rating_score: -1, asset_id: 1 }, limit: 4 })
+  await explainFind('homepage: recently updated', assets, PUBLIC_ASSET_FILTER,
+    { sort: { modify_date_at: -1, asset_id: 1 }, limit: 8 })
+  await explainAggregate('homepage: category counts', assets, [
+    { $match: PUBLIC_ASSET_FILTER },
+    { $group: { _id: '$category_lowercase', count: { $sum: 1 } } }
+  ])
+
+  // Search / taxonomy shapes.
+  const browseAll = buildSearchFilter('')
+  const browse2d = buildSearchFilter('', { categories: [sampleCategory] })
+  const filtered = buildSearchFilter('', { types: [sampleType], supports: ['official'] })
+  const textFilter = buildSearchFilter('shader')
+  const textAndFilters = buildSearchFilter('shader', { types: [sampleType] })
+
+  await explainAggregate('search: browse all (results+count)', assets,
+    searchPipeline(browseAll, { modify_date_at: -1, asset_id: 1 }))
+  await explainAggregate('search: category browse', assets,
+    searchPipeline(browse2d, { modify_date_at: -1, asset_id: 1 }))
+  await explainAggregate('search: text (results+count)', assets,
+    searchPipeline(textFilter, { score: { $meta: 'textScore' }, asset_id: 1 }))
+  await explainAggregate('search: filtered browse facet', assets, [
+    { $match: filtered },
+    { $group: { _id: '$category_lowercase', count: { $sum: 1 } } }
+  ])
+  await explainAggregate('search: text + filters facet', assets, [
+    { $match: textAndFilters },
+    { $group: { _id: '$type', count: { $sum: 1 } } }
+  ])
+
+  // PDP shapes.
+  await explainFind('pdp: asset by id', assets, { asset_id: sampleAssetId }, { limit: 1 })
+  await explainFind('pdp: related assets', assets,
+    { ...PUBLIC_ASSET_FILTER, asset_id: { $ne: 'none' }, category_lowercase: sampleCategory },
+    { sort: { rating_score: -1, upvotes: -1, asset_id: 1 }, limit: 12 })
+  await explainFind('pdp: reviews by asset', db.collection('reviews'),
+    { asset_id: sampleAssetId },
+    { sort: { date: -1, _id: -1 }, skip: 0, limit: 10 })
+  await explainAggregate('pdp: review count', db.collection('reviews'), [
+    { $match: { asset_id: sampleAssetId } },
+    { $count: 'n' }
+  ])
+
+  // Account shapes.
+  await explainFind('dashboard: user reviews', db.collection('reviews'),
+    { user_id: sampleUserId },
+    { sort: { date: -1, _id: -1 }, skip: 0, limit: 10 })
+
+  logger.log('info', '--- Query audit complete ---')
+}

--- a/src/core/maintenance/runQueryAudit.ts
+++ b/src/core/maintenance/runQueryAudit.ts
@@ -1,0 +1,17 @@
+import { MongoHelper } from 'core/MongoHelper'
+import { logger } from 'core/utils/logger'
+import { runQueryAudit } from './queryAudit'
+
+async function main (): Promise<void> {
+  try {
+    await MongoHelper.getInstance().connect()
+    await runQueryAudit()
+    MongoHelper.getInstance().disconnect()
+    process.exit(0)
+  } catch (e: any) {
+    logger.log('error', e?.message ?? 'Query audit failed')
+    process.exit(1)
+  }
+}
+
+void main()

--- a/src/core/migrations/0006-backfill-is-public.ts
+++ b/src/core/migrations/0006-backfill-is-public.ts
@@ -1,0 +1,38 @@
+import { Db } from 'mongodb'
+import { logger } from 'core/utils/logger'
+
+/**
+ * Backfill the denormalized `is_public` flag from the legacy public-catalog
+ * predicate (`source_status !== 'unavailable' && searchable !== 'false'`) so
+ * every discovery query can use a single indexed equality (`is_public: true`)
+ * instead of negative `$ne` predicates that defeat index selectivity.
+ *
+ * Only documents missing the field are touched, so the migration is idempotent
+ * and cheap to re-run. The importer (`normalizeAssetForSync` +
+ * `markSourceStatus`) keeps the flag current for new/updated assets afterwards.
+ */
+export async function backfillIsPublic (db: Db): Promise<void> {
+  const assets = db.collection('assets')
+
+  // Tombstoned upstream or explicitly non-searchable -> not public.
+  const hidden = await assets.updateMany(
+    {
+      is_public: { $exists: false },
+      $or: [{ source_status: 'unavailable' }, { searchable: 'false' }]
+    },
+    { $set: { is_public: false } }
+  )
+
+  // Everything else (including documents missing source_status/searchable,
+  // which the legacy `$ne` semantics treated as public) -> public.
+  const shown = await assets.updateMany(
+    {
+      is_public: { $exists: false },
+      source_status: { $ne: 'unavailable' },
+      searchable: { $ne: 'false' }
+    },
+    { $set: { is_public: true } }
+  )
+
+  logger.log('info', `Backfilled is_public: ${shown.modifiedCount ?? 0} public, ${hidden.modifiedCount ?? 0} hidden`)
+}

--- a/src/core/migrations/index.ts
+++ b/src/core/migrations/index.ts
@@ -5,6 +5,7 @@ import { backfillRatingScore } from './0002-backfill-rating-score'
 import { backfillModifyDate } from './0003-backfill-modify-date'
 import { dedupeReviewsAndIndex } from './0004-dedupe-reviews'
 import { backfillGodotMajor } from './0005-backfill-godot-major'
+import { backfillIsPublic } from './0006-backfill-is-public'
 
 export interface Migration {
   id: string
@@ -37,6 +38,11 @@ const MIGRATIONS: Migration[] = [
     id: '0005-backfill-godot-major',
     description: 'Backfill the numeric godot_major used by major-line browsing filters',
     run: backfillGodotMajor
+  },
+  {
+    id: '0006-backfill-is-public',
+    description: 'Backfill the denormalized is_public flag used by the public-catalog filter',
+    run: backfillIsPublic
   }
 ]
 

--- a/src/core/migrations/index.ts
+++ b/src/core/migrations/index.ts
@@ -43,20 +43,40 @@ const MIGRATIONS: Migration[] = [
 /**
  * Apply each unapplied migration in order, recording completion in the
  * `migrations` collection so the process is idempotent.
+ *
+ * Each migration runs independently: a failure in one is logged but never
+ * aborts the remaining migrations, so a single bad script cannot knock out
+ * the rest. A failed migration is NOT recorded as applied, so it is retried
+ * on the next run. If any migration failed, an Error naming the failures is
+ * thrown after the loop — standalone `npm run migrate` then exits non-zero,
+ * while startup (which wraps this call) logs it and still proceeds to
+ * `ensureIndexes()` as the safety net.
+ *
+ * `migrations` is injectable for tests and defaults to the real registry.
  */
-export async function runMigrations (db: Db): Promise<void> {
+export async function runMigrations (db: Db, migrations: Migration[] = MIGRATIONS): Promise<void> {
   const migrationCollection = db.collection('migrations')
+  const failures: string[] = []
 
-  for (const migration of MIGRATIONS) {
-    const applied = await migrationCollection.findOne({ id: migration.id })
-    if (applied !== null) {
-      logger.log('info', `Migration ${migration.id} already applied`)
-      continue
+  for (const migration of migrations) {
+    try {
+      const applied = await migrationCollection.findOne({ id: migration.id })
+      if (applied !== null) {
+        logger.log('info', `Migration ${migration.id} already applied`)
+        continue
+      }
+
+      logger.log('info', `Applying migration ${migration.id}: ${migration.description}`)
+      await migration.run(db)
+      await migrationCollection.insertOne({ id: migration.id, applied_at: new Date() })
+      logger.log('info', `Applied migration ${migration.id}`)
+    } catch (error: any) {
+      failures.push(migration.id)
+      logger.log('error', `Migration ${migration.id} failed (continuing with remaining migrations): ${error?.message ?? error}`, [error])
     }
+  }
 
-    logger.log('info', `Applying migration ${migration.id}: ${migration.description}`)
-    await migration.run(db)
-    await migrationCollection.insertOne({ id: migration.id, applied_at: new Date() })
-    logger.log('info', `Applied migration ${migration.id}`)
+  if (failures.length > 0) {
+    throw new Error(`Migration(s) failed: ${failures.join(', ')}`)
   }
 }

--- a/src/core/modules/authentication/models/user/GET/GetUserContextByToken.ts
+++ b/src/core/modules/authentication/models/user/GET/GetUserContextByToken.ts
@@ -41,10 +41,15 @@ async function loadUserContext (hashedToken: string): Promise<UserContext> {
  * only outlive a revocation by at most the TTL.
  */
 export async function GetUserContextByToken (hashedToken: string): Promise<UserContext> {
+  // The login context is security-sensitive: never extend it into a stale
+  // window. It is cached only for its short TTL and invalidated on logout and
+  // account deletion.
   const cached = await cacheGetOrLoad<UserContext>(
     buildUserContextCacheKey(hashedToken),
     USER_CONTEXT_CACHE_TTL_SECONDS,
-    async () => await loadUserContext(hashedToken)
+    async () => await loadUserContext(hashedToken),
+    undefined,
+    { staleTtlSeconds: 0 }
   )
   return cached.value
 }

--- a/src/core/start.ts
+++ b/src/core/start.ts
@@ -94,12 +94,24 @@ if (cluster.isPrimary) {
     }
     logger.log('info', `Forked ${workerCount} worker(s)`)
 
+    // Cluster-wide telemetry: workers ship their snapshots to the primary, which
+    // sums them and broadcasts a cluster view so ANY worker's /metrics reports
+    // the whole cluster. Entries are keyed by worker.id and removed on exit so
+    // a crashed/reforked worker can never inflate the aggregate.
+    const telemetrySnapshots = new Map<number, telemetry.TelemetrySnapshot>()
+
     // Auto-heal: replace a worker that crashed or was killed. A short delay
     // avoids a tight refork loop if something is wrong at boot, and reforking
     // is suppressed during an intentional shutdown so we never spin up workers
-    // that were just SIGTERM'd.
+    // that were just SIGTERM'd. Also drop the dead worker's telemetry snapshot
+    // and re-broadcast so cluster metrics never count exits/reforks twice.
     let shuttingDown = false
     cluster.on('exit', (worker, code, signal) => {
+      telemetrySnapshots.delete(worker.id)
+      const aggregate = telemetry.aggregateSnapshots([...telemetrySnapshots.values()])
+      for (const id of Object.keys(cluster.workers ?? {})) {
+        cluster.workers?.[id]?.send({ type: 'telemetry-cluster', aggregate })
+      }
       if (shuttingDown) {
         return
       }
@@ -111,13 +123,9 @@ if (cluster.isPrimary) {
       }, 1000)
     })
 
-    // Relay cache-invalidation broadcasts from any worker to all workers, so
-    // an admin site-file save made on one worker is reflected everywhere
-    // immediately (each worker keeps its own process-local site-files cache).
-    // Workers also ship their telemetry snapshots here; the primary sums them
-    // into a cluster-wide view and broadcasts it back so ANY worker's /metrics
-    // reports the whole cluster instead of just that one process.
-    const telemetrySnapshots = new Map<string, telemetry.TelemetrySnapshot>()
+    // Relay worker messages: admin site-file cache-invalidation (an admin save
+    // on one worker is reflected everywhere) and telemetry snapshots (summed
+    // above and broadcast back to every worker).
     cluster.on('message', (worker, message) => {
       const msg = message as {
         type?: string
@@ -129,7 +137,7 @@ if (cluster.isPrimary) {
           cluster.workers?.[id]?.send({ type: 'invalidate-site-files' })
         }
       } else if (msg?.type === 'telemetry-snapshot' && msg.snapshot !== undefined) {
-        telemetrySnapshots.set(String(worker.process?.pid ?? 'unknown'), msg.snapshot)
+        telemetrySnapshots.set(worker.id, msg.snapshot)
         const aggregate = telemetry.aggregateSnapshots([...telemetrySnapshots.values()])
         for (const id of Object.keys(cluster.workers ?? {})) {
           cluster.workers?.[id]?.send({ type: 'telemetry-cluster', aggregate })

--- a/src/core/start.ts
+++ b/src/core/start.ts
@@ -1,8 +1,10 @@
 import cluster from 'cluster'
+import http from 'http'
 import RouterServer from 'core/RouterServer'
 import { MongoHelper } from 'core/MongoHelper'
 import { logger } from 'core/utils/logger'
 import * as cronJobs from 'core/jobs.index'
+import * as telemetry from 'core/utils/telemetry'
 import { ensureIndexes } from 'core/ensureIndexes'
 import { runMigrations } from 'core/migrations'
 import { runGenerateSitemap } from 'app/utilities/sitemapGenerator/jobs/generateSitemap'
@@ -19,6 +21,12 @@ process.on('unhandledRejection', (reason) => {
   console.error('Unhandled Rejection:', reason)
   process.exit(1)
 })
+
+/** Read a positive drain timeout (ms) from an env var, falling back when unset/invalid. */
+function parseDrainTimeout (value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value ?? '', 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
 
 // Node cluster: the PRIMARY process does the one-time bootstrap (Mongo
 // connect, migrations, index checks, sitemap), runs every cron job exactly
@@ -59,6 +67,25 @@ if (cluster.isPrimary) {
       }
     }
 
+    // The public-catalog predicate is `{ is_public: true }` (migration 0006 +
+    // the importer keep it current). Verify the invariant before forking so a
+    // failed migration can never silently empty every public query — this is a
+    // loud warning, not a serving blocker (bootstrap stays best-effort).
+    try {
+      const assetsCollection = MongoHelper.getDatabase().collection('assets')
+      const totalAssets = await assetsCollection.countDocuments({})
+      if (totalAssets > 0) {
+        const missingIsPublic = await assetsCollection.countDocuments({ is_public: { $exists: false } })
+        if (missingIsPublic > 0) {
+          logger.log('error', `CRITICAL: ${missingIsPublic}/${totalAssets} assets missing is_public (migration 0006 may have failed) — public discovery queries will return empty until fixed`)
+        } else {
+          logger.log('info', `is_public coverage verified for ${totalAssets} assets`)
+        }
+      }
+    } catch (error: any) {
+      logger.log('warn', `is_public coverage check failed: ${error?.message ?? error}`)
+    }
+
     // Fork the HTTP workers after bootstrap so no worker ever serves before
     // migrations/indexes have been attempted.
     const workerCount = getWorkerCount()
@@ -87,29 +114,71 @@ if (cluster.isPrimary) {
     // Relay cache-invalidation broadcasts from any worker to all workers, so
     // an admin site-file save made on one worker is reflected everywhere
     // immediately (each worker keeps its own process-local site-files cache).
-    cluster.on('message', (_worker, message) => {
-      const msg = message as { type?: string } | null
+    // Workers also ship their telemetry snapshots here; the primary sums them
+    // into a cluster-wide view and broadcasts it back so ANY worker's /metrics
+    // reports the whole cluster instead of just that one process.
+    const telemetrySnapshots = new Map<string, telemetry.TelemetrySnapshot>()
+    cluster.on('message', (worker, message) => {
+      const msg = message as {
+        type?: string
+        snapshot?: telemetry.TelemetrySnapshot
+        aggregate?: telemetry.TelemetrySnapshot
+      } | null
       if (msg?.type === 'invalidate-site-files') {
         for (const id of Object.keys(cluster.workers ?? {})) {
           cluster.workers?.[id]?.send({ type: 'invalidate-site-files' })
+        }
+      } else if (msg?.type === 'telemetry-snapshot' && msg.snapshot !== undefined) {
+        telemetrySnapshots.set(String(worker.process?.pid ?? 'unknown'), msg.snapshot)
+        const aggregate = telemetry.aggregateSnapshots([...telemetrySnapshots.values()])
+        for (const id of Object.keys(cluster.workers ?? {})) {
+          cluster.workers?.[id]?.send({ type: 'telemetry-cluster', aggregate })
         }
       }
     })
 
     // Let Docker/systemd stop the cluster cleanly. Idempotent so a SIGTERM and
-    // SIGINT arriving together only trigger one shutdown.
+    // SIGINT arriving together only trigger one shutdown. Workers drain their
+    // in-flight requests first; the primary waits for them with a bounded
+    // deadline so deployments don't drop active requests.
     const shutdown = (): void => {
       if (shuttingDown) {
         return
       }
       shuttingDown = true
-      logger.log('info', 'Primary shutting down; terminating workers')
-      for (const id of Object.keys(cluster.workers ?? {})) {
-        cluster.workers?.[id]?.kill('SIGTERM')
+      logger.log('info', 'Primary shutting down; signaling workers to drain')
+
+      const workers = Object.values(cluster.workers ?? {})
+        .filter((worker): worker is NonNullable<typeof worker> => worker !== undefined)
+      const drainTimeoutMs = parseDrainTimeout(process.env.PRIMARY_DRAIN_TIMEOUT_MS, 15_000)
+      const timer = setTimeout(() => {
+        logger.log('warn', 'Primary drain deadline exceeded; exiting')
+        void disconnectDragonfly()
+        MongoHelper.getInstance().disconnect()
+        process.exit(0)
+      }, drainTimeoutMs)
+      timer.unref()
+
+      const finish = (): void => {
+        clearTimeout(timer)
+        void disconnectDragonfly()
+        MongoHelper.getInstance().disconnect()
+        process.exit(0)
       }
-      void disconnectDragonfly()
-      MongoHelper.getInstance().disconnect()
-      process.exit(0)
+
+      if (workers.length === 0) {
+        finish()
+        return
+      }
+
+      let remaining = workers.length
+      for (const worker of workers) {
+        worker.once('exit', () => {
+          remaining -= 1
+          if (remaining === 0) finish()
+        })
+        worker.kill('SIGTERM')
+      }
     }
     process.on('SIGTERM', shutdown)
     process.on('SIGINT', shutdown)
@@ -121,26 +190,78 @@ if (cluster.isPrimary) {
   // Worker: connect to MongoDB and serve HTTP only. No migrations, index
   // checks, sitemap generation or cron here — those run once in the primary.
   //
-  // Listen for site-file cache-invalidation broadcasts from the primary (an
-  // admin save happened on another worker) and invalidate this worker's cache.
+  // Listen for broadcasts from the primary: site-file cache invalidation (an
+  // admin save happened on another worker) and the aggregated cluster
+  // telemetry view used by /metrics.
   process.on('message', (message: unknown) => {
-    const msg = message as { type?: string } | null
+    const msg = message as {
+      type?: string
+      aggregate?: telemetry.TelemetrySnapshot
+    } | null
     if (msg?.type === 'invalidate-site-files') {
       invalidateSiteFileCacheLocally()
+    } else if (msg?.type === 'telemetry-cluster' && msg.aggregate !== undefined) {
+      telemetry.setClusterSnapshot(msg.aggregate)
     }
   })
 
-  const shutdownWorker = (): void => {
-    void disconnectDragonfly().finally(() => process.exit(0))
+  // Periodically ship this worker's telemetry snapshot to the primary so it
+  // can aggregate a cluster-wide view for /metrics on any worker.
+  const parsedAggregateMs = Number.parseInt(process.env.TELEMETRY_AGGREGATE_INTERVAL_MS ?? '', 10)
+  const aggregateIntervalMs = Number.isFinite(parsedAggregateMs) && parsedAggregateMs > 0 ? parsedAggregateMs : 10_000
+  const aggregateTimer = setInterval(() => {
+    if (process.send !== undefined) {
+      process.send({ type: 'telemetry-snapshot', snapshot: telemetry.snapshot() })
+    }
+  }, aggregateIntervalMs)
+  aggregateTimer.unref()
+
+  let httpServer: http.Server | null = null
+  let draining = false
+
+  // Graceful drain: stop accepting new connections, let in-flight requests
+  // finish, close idle keep-alive sockets, then exit after a bounded deadline.
+  // This prevents deployments/restarts from dropping active requests.
+  const shutdownWorker = (signal: string): void => {
+    if (draining) return
+    draining = true
+    logger.log('info', `Worker ${process.pid} received ${signal}; draining`)
+    const drainTimeoutMs = parseDrainTimeout(process.env.WORKER_DRAIN_TIMEOUT_MS, 10_000)
+    const forceExit = setTimeout(() => {
+      logger.log('warn', `Worker ${process.pid} drain deadline exceeded; forcing exit`)
+      process.exit(0)
+    }, drainTimeoutMs)
+    forceExit.unref()
+
+    const finish = (): void => {
+      clearTimeout(forceExit)
+      void disconnectDragonfly().finally(() => process.exit(0))
+    }
+
+    if (httpServer !== null) {
+      // Close idle keep-alive connections so server.close() completes instead
+      // of waiting for Cloudflare's long-lived sockets to age out.
+      const closeIdle = (httpServer as any).closeIdleConnections
+      if (typeof closeIdle === 'function') closeIdle.call(httpServer)
+      httpServer.close((error) => {
+        if (error !== undefined) {
+          logger.log('error', `Worker ${process.pid} close error: ${error.message}`)
+        }
+        finish()
+      })
+    } else {
+      finish()
+    }
   }
-  process.on('SIGTERM', shutdownWorker)
-  process.on('SIGINT', shutdownWorker)
+
+  process.on('SIGTERM', () => shutdownWorker('SIGTERM'))
+  process.on('SIGINT', () => shutdownWorker('SIGINT'))
 
   MongoHelper.getInstance().connect().then(() => {
     const startTime: Date = new Date()
     logger.log('info', `Worker ${process.pid} ready at ${startTime}`)
-    const server: RouterServer = new RouterServer()
-    server.start(3000)
+    const router: RouterServer = new RouterServer()
+    httpServer = router.start(3000)
     // Warm the site-files cache now that Mongo is connected so the first
     // public request serves immediately instead of 404ing on an empty cache.
     primeSiteFilesCache()

--- a/src/core/utils/clusterConfig.ts
+++ b/src/core/utils/clusterConfig.ts
@@ -3,6 +3,13 @@ import os from 'os'
 const MAX_WORKERS = 16
 
 /**
+ * Worst-case TOTAL MongoDB connection budget across every process in the
+ * cluster (HTTP workers + primary). Per-process ceilings are derived from this
+ * budget so the aggregate can never exceed it, no matter how many workers run.
+ */
+export const DEFAULT_TOTAL_POOL_BUDGET = 1500
+
+/**
  * How many HTTP worker processes the cluster should run.
  *
  * Set WORKER_COUNT explicitly (e.g. to your container's CPU allocation); the
@@ -20,18 +27,27 @@ export function getWorkerCount (): number {
 }
 
 /**
- * Default per-process MongoDB pool ceiling.
+ * Default per-process MongoDB pool ceiling for HTTP workers.
  *
- * Every cluster worker AND the primary owns its own MongoClient (the primary
- * connects for bootstrap and cron), so this sizes each pool so the TOTAL
- * worst-case connections stay bounded regardless of cluster size (~1500 across
- * the whole cluster): 1 worker -> 750 each (worker + primary), 4 workers ->
- * 300 each (4 workers + primary), etc. This keeps MongoDB from being hit with
- * `processes x pool` connections by accident. An explicit MONGO_MAX_POOL env
- * override always wins.
+ * Every cluster worker AND the primary owns its own MongoClient, so the
+ * per-worker ceiling is the total budget divided by the process count (workers
+ * + primary) using floor() so the aggregate NEVER exceeds the budget — even at
+ * 16 workers (~88/process) instead of the old 200-per-process floor that
+ * allowed up to ~3400 total connections. The pool is lazy (a ceiling, not a
+ * target), and an explicit MONGO_MAX_POOL env override always wins.
  */
 export function getDefaultMongoPool (): number {
   const workerCount = getWorkerCount()
-  // +1 includes the primary process, which also connects to MongoDB.
-  return Math.max(200, Math.round(1500 / (workerCount + 1)))
+  return Math.max(64, Math.floor(DEFAULT_TOTAL_POOL_BUDGET / (workerCount + 1)))
+}
+
+/**
+ * Mongo pool ceiling for the cluster PRIMARY (bootstrap + cron only, no HTTP).
+ * It never serves requests, so it needs far fewer connections than a worker;
+ * keeping it small leaves more of the budget for the workers that actually
+ * handle traffic.
+ */
+export function getPrimaryMongoPool (): number {
+  const workerCount = getWorkerCount()
+  return Math.max(16, Math.floor(DEFAULT_TOTAL_POOL_BUDGET / (workerCount + 1) / 4))
 }

--- a/src/core/utils/dragonfly.ts
+++ b/src/core/utils/dragonfly.ts
@@ -10,8 +10,17 @@ const DEFAULT_URL = 'redis://dragonfly:6379'
 const CONNECT_TIMEOUT_MS = 1000
 const COMMAND_TIMEOUT_MS = 750
 const RECONNECT_DELAY_MS = 10_000
+const ENVELOPE_VERSION = 2
 const DEFAULT_LOCK_MS = 5000
-const DEFAULT_WAIT_MS = 1500
+const DEFAULT_STALE_TTL_SECONDS = 86_400
+
+const parsedWaitMs = Number.parseInt(process.env.CACHE_COALESCE_WAIT_MS ?? '', 10)
+const DEFAULT_WAIT_MS = Number.isFinite(parsedWaitMs) && parsedWaitMs > 0 ? parsedWaitMs : 3000
+
+const parsedL1Bytes = Number.parseInt(process.env.CACHE_L1_BYTES ?? '', 10)
+const L1_MAX_BYTES = Number.isFinite(parsedL1Bytes) && parsedL1Bytes > 0 ? parsedL1Bytes : 32 * 1024 * 1024
+const parsedL1Entries = Number.parseInt(process.env.CACHE_L1_MAX_ENTRIES ?? '', 10)
+const L1_MAX_ENTRIES = Number.isFinite(parsedL1Entries) && parsedL1Entries > 0 ? parsedL1Entries : 2000
 
 let client: DragonflyClient | null = null
 let connectPromise: Promise<DragonflyClient | null> | null = null
@@ -100,11 +109,102 @@ async function cacheCommand<T> (operation: (connected: DragonflyClient) => Promi
   }
 }
 
-export async function cacheGetJson<T> (key: string): Promise<T | null> {
+export interface CacheEnvelope<T> {
+  v: number
+  value: T
+  freshUntil: number
+  staleUntil: number
+}
+
+/** Build a fresh+stale envelope with the given source TTLs (ms). */
+export function buildEnvelope<T> (value: T, freshTtlMs: number, staleTtlMs: number, now = Date.now()): CacheEnvelope<T> {
+  const freshUntil = now + freshTtlMs
+  const staleUntil = now + freshTtlMs + staleTtlMs
+  return { v: ENVELOPE_VERSION, value, freshUntil, staleUntil }
+}
+
+/** True while the envelope is still within its freshness window. */
+export function isEnvelopeFresh<T> (envelope: CacheEnvelope<T>, now = Date.now()): boolean {
+  return now < envelope.freshUntil
+}
+
+/** True when the envelope may still be served as stale (past fresh, before hard stale). */
+export function isEnvelopeStaleServable<T> (envelope: CacheEnvelope<T>, now = Date.now()): boolean {
+  return envelope.freshUntil <= now && now < envelope.staleUntil
+}
+
+function defaultStaleTtlSeconds (): number {
+  const parsed = Number.parseInt(process.env.CACHE_STALE_TTL_SECONDS ?? '', 10)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_STALE_TTL_SECONDS
+}
+
+/**
+ * Per-worker byte-bounded L1 cache. Every request looks here first, and it
+ * survives a Dragonfly outage, so a small bounded L1 shrinks the blast radius
+ * when the shared cache fails. The budget is bounded per worker
+ * (CACHE_L1_BYTES) so duplicated L1 memory across workers stays predictable.
+ */
+interface L1Entry {
+  envelope: CacheEnvelope<unknown>
+  bytes: number
+}
+
+const l1 = new Map<string, L1Entry>()
+let l1Bytes = 0
+
+function l1Delete (key: string): void {
+  const entry = l1.get(key)
+  if (entry !== undefined) {
+    l1Bytes -= entry.bytes
+    l1.delete(key)
+  }
+}
+
+function l1Get<T> (key: string, now: number, allowStale: boolean): CacheEnvelope<T> | null {
+  const entry = l1.get(key)
+  if (entry === undefined) return null
+  const envelope = entry.envelope as CacheEnvelope<T>
+  if (isEnvelopeFresh(envelope, now) || (allowStale && isEnvelopeStaleServable(envelope, now))) {
+    // LRU touch: move to the back of the Map (most recently used).
+    l1.delete(key)
+    l1.set(key, entry)
+    return envelope
+  }
+  l1Delete(key)
+  return null
+}
+
+function l1Set<T> (key: string, envelope: CacheEnvelope<T>): void {
+  const bytes = Buffer.byteLength(key, 'utf8') + Buffer.byteLength(JSON.stringify(envelope), 'utf8')
+  l1Delete(key)
+  l1.set(key, { envelope: envelope as CacheEnvelope<unknown>, bytes })
+  l1Bytes += bytes
+  // Evict oldest entries until under the byte and entry budgets.
+  while ((l1Bytes > L1_MAX_BYTES || l1.size > L1_MAX_ENTRIES) && l1.size > 0) {
+    const oldestKey = l1.keys().next().value as string | undefined
+    if (oldestKey === undefined) break
+    l1Delete(oldestKey)
+  }
+}
+
+export async function cacheDelete (...keys: string[]): Promise<void> {
+  for (const key of keys) l1Delete(key)
+  if (keys.length === 0) return
+  await cacheCommand(async connected => await connected.del(keys))
+}
+
+async function cacheGetEnvelope<T> (key: string): Promise<CacheEnvelope<T> | null> {
   const raw = await cacheCommand(async connected => await connected.get(key))
-  if (typeof raw !== 'string') return null
+  if (typeof raw !== 'string' || raw === '') return null
   try {
-    return JSON.parse(raw) as T
+    const parsed = JSON.parse(raw) as CacheEnvelope<T>
+    if (parsed === null || typeof parsed !== 'object' || parsed.v !== ENVELOPE_VERSION ||
+        typeof parsed.freshUntil !== 'number' || typeof parsed.staleUntil !== 'number') {
+      // Old-format (pre-envelope) entries are dropped and re-filled on demand.
+      void cacheDelete(key)
+      return null
+    }
+    return parsed
   } catch {
     telemetry.recordCacheError()
     void cacheDelete(key)
@@ -112,68 +212,243 @@ export async function cacheGetJson<T> (key: string): Promise<T | null> {
   }
 }
 
-export async function cacheSetJson (key: string, value: unknown, ttlSeconds: number): Promise<boolean> {
-  if (!Number.isFinite(ttlSeconds) || ttlSeconds <= 0) return false
-  const stored = await cacheCommand(async connected => await connected.set(key, JSON.stringify(value), { EX: Math.ceil(ttlSeconds) }))
+async function cacheSetEnvelope<T> (key: string, envelope: CacheEnvelope<T>): Promise<boolean> {
+  const ttlMs = envelope.staleUntil - Date.now()
+  if (ttlMs <= 0) return false
+  const stored = await cacheCommand(async connected =>
+    await connected.set(key, JSON.stringify(envelope), { EX: Math.ceil(ttlMs / 1000) })
+  )
   return stored === 'OK'
 }
 
-export async function cacheDelete (...keys: string[]): Promise<void> {
-  if (keys.length === 0) return
-  await cacheCommand(async connected => await connected.del(keys))
+// Atomic compare-and-delete so an expired/replaced lock can never be deleted
+// by a previous owner (the old GET-then-DEL raced and could delete a new
+// owner's lock).
+const RELEASE_LOCK_SCRIPT = `
+if redis.call('get', KEYS[1]) == ARGV[1] then
+  return redis.call('del', KEYS[1])
+end
+return 0
+`
+
+async function releaseLock (lockKey: string, token: string): Promise<void> {
+  await cacheCommand(async connected => await connected.eval(RELEASE_LOCK_SCRIPT, {
+    keys: [lockKey],
+    arguments: [token]
+  }))
 }
 
+async function sleepJittered (baseMs: number): Promise<void> {
+  const jitter = Math.floor(Math.random() * baseMs * 0.5)
+  await new Promise<void>(resolve => {
+    const timer = setTimeout(resolve, baseMs + jitter)
+    timer.unref()
+  })
+}
+
+async function safeEpoch (read: () => Promise<string | null>): Promise<string | null> {
+  try {
+    return await read()
+  } catch {
+    return null
+  }
+}
+
+export interface CacheGetOrLoadOptions {
+  /** Distributed lock TTL for one fill (ms). */
+  lockMs?: number
+  /** How long followers wait for another worker's cold fill before loading themselves (ms). */
+  waitMs?: number
+  /** How long past freshness a value stays servable as stale (seconds). 0 disables stale serving. */
+  staleTtlSeconds?: number
+  /**
+   * Optional source fence. When the epoch changes between the pre-load read and
+   * the post-load read, the write is skipped so an older in-flight loader can
+   * never repopulate the cache after an invalidation.
+   */
+  epoch?: () => Promise<string | null>
+}
+
+// Per-process single-flight: while one request loads a key, every other
+// request in this worker awaits the same promise instead of re-running the
+// loader. Together with the distributed lock this prevents cache stampedes.
+const inflight = new Map<string, Promise<{ value: any, hit: boolean }>>()
+const refreshing = new Set<string>()
+
+/**
+ * Load a value from the two-level cache: bounded per-worker L1, then Dragonfly.
+ *
+ * Public snapshots stay fresh for `ttlSeconds` and then remain servable as
+ * stale (returned immediately while one owner refreshes in the background) for
+ * the stale window, so an origin/database failure serves the last known good
+ * value instead of failing every request. Fail-open: any Dragonfly problem
+ * degrades to loading the source directly.
+ */
 export async function cacheGetOrLoad<T> (
   key: string,
   ttlSeconds: number,
   loader: () => Promise<T>,
-  lockMs = DEFAULT_LOCK_MS
+  lockMs = DEFAULT_LOCK_MS,
+  options: CacheGetOrLoadOptions = {}
 ): Promise<{ value: T, hit: boolean }> {
-  const cached = await cacheGetJson<T>(key)
-  if (cached !== null) {
+  const now = Date.now()
+  const freshTtlMs = ttlSeconds * 1000
+  const staleTtlSeconds = options.staleTtlSeconds ?? defaultStaleTtlSeconds()
+  const staleTtlMs = staleTtlSeconds > 0 ? staleTtlSeconds * 1000 : 0
+  const allowStale = staleTtlMs > 0
+  const waitMs = options.waitMs ?? DEFAULT_WAIT_MS
+
+  // L1 serves regardless of Dragonfly state (survives an outage).
+  const l1Entry = l1Get<T>(key, now, allowStale)
+  if (l1Entry !== null) {
+    telemetry.recordCacheL1Hit()
     telemetry.recordCacheHit()
-    return { value: cached, hit: true }
+    if (allowStale && isEnvelopeStaleServable(l1Entry, now)) {
+      telemetry.recordCacheStaleHit()
+      refreshInBackground(key, freshTtlMs, staleTtlMs, loader, lockMs, options)
+    }
+    return { value: l1Entry.value, hit: true }
   }
 
   const connected = await getClient()
   if (connected === null) {
+    telemetry.recordCacheBypass()
     telemetry.recordCacheMiss()
     return { value: await loader(), hit: false }
   }
 
+  const envelope = await cacheGetEnvelope<T>(key)
+  if (envelope !== null && isEnvelopeFresh(envelope, now)) {
+    l1Set(key, envelope)
+    telemetry.recordCacheHit()
+    return { value: envelope.value, hit: true }
+  }
+  if (envelope !== null && allowStale && isEnvelopeStaleServable(envelope, now)) {
+    l1Set(key, envelope)
+    telemetry.recordCacheHit()
+    telemetry.recordCacheStaleHit()
+    refreshInBackground(key, freshTtlMs, staleTtlMs, loader, lockMs, options)
+    return { value: envelope.value, hit: true }
+  }
+
+  const pending = inflight.get(key)
+  if (pending !== undefined) {
+    telemetry.recordCacheCoalescedWait()
+    const result = await pending
+    telemetry.recordCacheHit()
+    return { value: result.value, hit: true }
+  }
+
+  const load = loadValue(key, freshTtlMs, staleTtlMs, allowStale, loader, lockMs, waitMs, options)
+  inflight.set(key, load)
+  try {
+    return await load
+  } finally {
+    inflight.delete(key)
+  }
+}
+
+async function loadValue<T> (
+  key: string,
+  freshTtlMs: number,
+  staleTtlMs: number,
+  allowStale: boolean,
+  loader: () => Promise<T>,
+  lockMs: number,
+  waitMs: number,
+  options: CacheGetOrLoadOptions
+): Promise<{ value: T, hit: boolean }> {
   const lockKey = `${key}:lock`
   const lockToken = `${process.pid}:${randomBytes(8).toString('hex')}`
-  const acquired = await cacheCommand(async current => await current.set(lockKey, lockToken, { NX: true, PX: lockMs }))
+  const acquired = await cacheCommand(async current =>
+    await current.set(lockKey, lockToken, { NX: true, PX: lockMs })
+  )
 
   if (acquired === 'OK') {
     try {
+      const epochBefore = options.epoch !== undefined ? await safeEpoch(options.epoch) : null
       const value = await loader()
-      await cacheSetJson(key, value, ttlSeconds)
+      const epochAfter = options.epoch !== undefined ? await safeEpoch(options.epoch) : null
+      if (epochBefore === null || epochAfter === null || epochBefore === epochAfter) {
+        const envelope = buildEnvelope(value, freshTtlMs, staleTtlMs)
+        l1Set(key, envelope)
+        await cacheSetEnvelope(key, envelope)
+      }
       telemetry.recordCacheMiss()
       return { value, hit: false }
     } finally {
-      const currentLock = await cacheCommand(async current => await current.get(lockKey))
-      if (currentLock === lockToken) await cacheDelete(lockKey)
+      await releaseLock(lockKey, lockToken)
     }
   }
 
-  // Another worker is filling this key. Wait briefly for its result instead
-  // of stampeding MongoDB, but never make Dragonfly a hard dependency.
-  const deadline = Date.now() + Math.min(DEFAULT_WAIT_MS, lockMs)
+  // Another worker holds the fill lock: poll with jittered backoff for its
+  // result instead of stampeding the source. Fall through only after the
+  // bounded wait so a genuine cold fill under pressure still completes.
+  telemetry.recordCacheCoalescedWait()
+  const deadline = Date.now() + waitMs
+  let baseDelay = 50
   while (Date.now() < deadline) {
-    await new Promise<void>(resolve => {
-      const timer = setTimeout(resolve, 25)
-      timer.unref()
-    })
-    const filled = await cacheGetJson<T>(key)
-    if (filled !== null) {
+    await sleepJittered(baseDelay)
+    const filled = await cacheGetEnvelope<T>(key)
+    if (filled !== null && (isEnvelopeFresh(filled) || (allowStale && isEnvelopeStaleServable(filled)))) {
+      l1Set(key, filled)
       telemetry.recordCacheHit()
-      return { value: filled, hit: true }
+      return { value: filled.value, hit: true }
     }
+    baseDelay = Math.min(baseDelay * 1.8, 300)
   }
 
   telemetry.recordCacheMiss()
   return { value: await loader(), hit: false }
+}
+
+/**
+ * Kick off a single-flight background refresh for a key that was served stale.
+ * The current request returns stale immediately; the refresh (bounded by the
+ * distributed lock) re-populates fresh data. On failure the stale value is
+ * kept and served again. Errors never reach callers.
+ */
+function refreshInBackground<T> (
+  key: string,
+  freshTtlMs: number,
+  staleTtlMs: number,
+  loader: () => Promise<T>,
+  lockMs: number,
+  options: CacheGetOrLoadOptions
+): void {
+  if (refreshing.has(key)) return
+  refreshing.add(key)
+  void (async () => {
+    try {
+      const connected = await getClient()
+      if (connected === null) return
+      const lockKey = `${key}:lock`
+      const lockToken = `${process.pid}:${randomBytes(8).toString('hex')}`
+      const acquired = await cacheCommand(async current =>
+        await current.set(lockKey, lockToken, { NX: true, PX: lockMs })
+      )
+      if (acquired !== 'OK') return
+      try {
+        const epochBefore = options.epoch !== undefined ? await safeEpoch(options.epoch) : null
+        const value = await loader()
+        const epochAfter = options.epoch !== undefined ? await safeEpoch(options.epoch) : null
+        if (epochBefore === null || epochAfter === null || epochBefore === epochAfter) {
+          const envelope = buildEnvelope(value, freshTtlMs, staleTtlMs)
+          l1Set(key, envelope)
+          await cacheSetEnvelope(key, envelope)
+        }
+        telemetry.recordCacheRefresh()
+      } catch {
+        telemetry.recordCacheRefreshFailure()
+      } finally {
+        await releaseLock(lockKey, lockToken)
+      }
+    } catch {
+      telemetry.recordCacheRefreshFailure()
+    } finally {
+      refreshing.delete(key)
+    }
+  })()
 }
 
 /**
@@ -201,6 +476,35 @@ export function buildAllAssetCacheKeys (assetId: string): string[] {
  */
 export function buildUserContextCacheKey (hashedToken: string): string {
   return `gda:v1:userctx:${hashedToken}`
+}
+
+const ASSET_EPOCH_PREFIX = 'gda:v2:assetepoch:'
+
+/** Per-asset mutation generation key used to fence in-flight cache fills. */
+export function buildAssetEpochKey (assetId: string): string {
+  return `${ASSET_EPOCH_PREFIX}${assetId}`
+}
+
+/**
+ * Read the current mutation generation for an asset. Returns null when no
+ * mutation has ever occurred or the cache is unavailable (fail-open).
+ */
+export async function getAssetEpoch (assetId: string): Promise<string | null> {
+  return await cacheCommand(async connected => await connected.get(buildAssetEpochKey(assetId)))
+}
+
+/**
+ * Invalidate every PDP cache variant for an asset and bump its mutation
+ * generation first, so an older in-flight loader that started before this
+ * mutation cannot repopulate the cache with stale data (the fence skips its
+ * write because the epoch changed under it). Fail-open: if Dragonfly is down
+ * the delete is a no-op and the bounded TTL bounds any residual staleness.
+ */
+export async function invalidateAssetCache (assetId: string): Promise<void> {
+  await cacheCommand(async connected => await connected.incr(buildAssetEpochKey(assetId)))
+  const variants = buildAllAssetCacheKeys(assetId)
+  for (const variant of variants) l1Delete(variant)
+  await cacheDelete(...variants)
 }
 
 export async function disconnectDragonfly (): Promise<void> {

--- a/src/core/utils/httpCachePolicy.ts
+++ b/src/core/utils/httpCachePolicy.ts
@@ -1,0 +1,121 @@
+import { GODOT_VERSION_PREFERENCE_COOKIE } from 'core/utils/godotVersionPreference'
+
+/**
+ * Centralized HTTP cache-policy classification.
+ *
+ * Only anonymous, canonical, deterministic GET/HEAD responses are eligible for
+ * shared (edge/CDN) caching. Everything personalized, cookie-varying, mutated,
+ * or high-cardinality must never be stored by a shared cache. This module is a
+ * pure classifier so the exact header matrix is unit-testable without Express.
+ */
+
+const AUTH_COOKIE = 'auth-token'
+const MAX_CACHEABLE_PAGE = 1000
+const PAGE_RE = /^\d{1,4}$/
+
+export interface CachePolicy {
+  /** Browser max-age in seconds. */
+  browserMaxAge: number
+  /** Shared (CDN/edge) max-age in seconds. */
+  sharedMaxAge: number
+  staleWhileRevalidate: number
+  staleIfError: number
+}
+
+/**
+ * Anonymous canonical public pages: short browser freshness so users see
+ * changes quickly, a five-minute shared-cache lifetime for the edge, a
+ * stale-while-revalidate window so the edge can serve slightly stale pages
+ * while revalidating, and a 24-hour stale-if-error window so the site keeps
+ * serving the last known good page even while the origin is down or broken.
+ */
+export const PUBLIC_CACHE_POLICY: CachePolicy = {
+  browserMaxAge: 60,
+  sharedMaxAge: 300,
+  staleWhileRevalidate: 300,
+  staleIfError: 86_400
+}
+
+export function buildPublicCacheControl (policy: CachePolicy = PUBLIC_CACHE_POLICY): string {
+  return `public, max-age=${policy.browserMaxAge}, s-maxage=${policy.sharedMaxAge}, ` +
+    `stale-while-revalidate=${policy.staleWhileRevalidate}, stale-if-error=${policy.staleIfError}`
+}
+
+export interface CacheRequestLike {
+  method: string
+  path: string
+  query: Record<string, unknown>
+  cookies?: Record<string, unknown>
+}
+
+/** Only a numeric, bounded `page` query parameter is accepted. */
+function hasOnlyPageParam (query: Record<string, unknown>): boolean {
+  const keys = Object.keys(query)
+  if (keys.length === 0) return true
+  if (keys.length !== 1 || keys[0] !== 'page') return false
+  const raw = query.page
+  if (Array.isArray(raw)) return false
+  const value = String(raw ?? '')
+  if (!PAGE_RE.test(value)) return false
+  const page = Number.parseInt(value, 10)
+  return page >= 1 && page <= MAX_CACHEABLE_PAGE
+}
+
+function hasNoQuery (query: Record<string, unknown>): boolean {
+  return Object.keys(query).length === 0
+}
+
+/**
+ * True when the request path+query resolves to one of the finite, canonical,
+ * deterministic public views that a shared cache may store. Search queries,
+ * filter combinations, review pagination, `from=` variants and any other
+ * high-cardinality or request-specific variants return false.
+ */
+export function isPubliclyCacheablePath (
+  method: string,
+  path: string,
+  query: Record<string, unknown>
+): boolean {
+  if (method !== 'GET' && method !== 'HEAD') return false
+
+  if (path === '/') return hasNoQuery(query)
+  if (path === '/search/') return hasOnlyPageParam(query)
+  if (/^\/category\/[^/]+$/.test(path)) return hasOnlyPageParam(query)
+  if (/^\/engine\/[^/]+$/.test(path)) return hasOnlyPageParam(query)
+  // Canonical asset detail page: only the anonymous first review page with no
+  // request-specific params (no `from`, no `reviews_page`).
+  if (/^\/asset\/[^/]+\/[^/]+/.test(path)) return hasNoQuery(query)
+  if (/^\/guides(?:\/[^/]+)?\/?$/.test(path)) return hasNoQuery(query)
+  return false
+}
+
+/**
+ * Decide the Cache-Control directive for a request, or null when the request
+ * should be left alone (non-GET/HEAD). Never clobbers a header set by an
+ * earlier middleware (callers must check that first).
+ */
+export function classifyCacheControl (req: CacheRequestLike): string | null {
+  if (req.method !== 'GET' && req.method !== 'HEAD') return null
+
+  const cookies = req.cookies ?? {}
+  const authToken = cookies[AUTH_COOKIE]
+  const versionCookie = cookies[GODOT_VERSION_PREFERENCE_COOKIE]
+  const hasVersionCookie = versionCookie !== undefined && versionCookie !== ''
+
+  // Personalized/authenticated responses must never be shared-cached.
+  if (authToken !== undefined && authToken !== '') {
+    return 'private, no-store'
+  }
+
+  // Responses that vary by the Godot-version cookie stay browser-only.
+  if (hasVersionCookie) {
+    return 'private, max-age=120'
+  }
+
+  // Anonymous canonical views get the aggressive shared policy; every other
+  // anonymous GET is browser-cacheable but not shared-cacheable.
+  if (isPubliclyCacheablePath(req.method, req.path, req.query)) {
+    return buildPublicCacheControl()
+  }
+  return 'private, max-age=120'
+}

--- a/src/core/utils/httpCachePolicy.ts
+++ b/src/core/utils/httpCachePolicy.ts
@@ -83,8 +83,10 @@ export function isPubliclyCacheablePath (
   if (/^\/category\/[^/]+$/.test(path)) return hasOnlyPageParam(query)
   if (/^\/engine\/[^/]+$/.test(path)) return hasOnlyPageParam(query)
   // Canonical asset detail page: only the anonymous first review page with no
-  // request-specific params (no `from`, no `reviews_page`).
-  if (/^\/asset\/[^/]+\/[^/]+/.test(path)) return hasNoQuery(query)
+  // request-specific params (no `from`, no `reviews_page`). End-anchored so
+  // deeper non-canonical variants (which 301 to the canonical slug) are never
+  // shared-cached.
+  if (/^\/asset\/[^/]+\/[^/]+\/?$/.test(path)) return hasNoQuery(query)
   if (/^\/guides(?:\/[^/]+)?\/?$/.test(path)) return hasNoQuery(query)
   return false
 }

--- a/src/core/utils/publicCatalog.ts
+++ b/src/core/utils/publicCatalog.ts
@@ -4,13 +4,13 @@
  * counts, facets, homepage sections, related assets, the sitemap and the
  * detail-page robots policy so they always agree.
  *
- * Mirrors the previous sitemap-only exclusions:
- * - `source_status === 'unavailable'` assets are tombstones for assets removed
- *   upstream and must never surface in discovery or receive internal links.
- * - `searchable === 'false'` assets were excluded by the upstream catalog and
- *   should not be advertised.
+ * Uses the denormalized `is_public` boolean (equality) instead of negative
+ * `$ne` predicates so discovery queries can use normal/partial index
+ * semantics. The flag is derived from the legacy predicate — an asset is
+ * public when `source_status !== 'unavailable'` (upstream tombstones) AND
+ * `searchable !== 'false'` (excluded by the upstream catalog). Migration
+ * `0006` backfills existing documents and the importer keeps it current.
  */
 export const PUBLIC_ASSET_FILTER: Record<string, unknown> = {
-  source_status: { $ne: 'unavailable' },
-  searchable: { $ne: 'false' }
+  is_public: true
 }

--- a/src/core/utils/releaseId.ts
+++ b/src/core/utils/releaseId.ts
@@ -1,0 +1,46 @@
+import fs from 'fs'
+import path from 'path'
+
+let cachedReleaseId: string | null = null
+
+/**
+ * A stable identifier for the current deployment, shared by every worker and
+ * replica so static-asset cache busters (`?cache=<id>`) converge instead of
+ * differing per worker restart (which previously created duplicate cached
+ * copies and cold static traffic on every refork).
+ *
+ * Prefer the RELEASE_ID environment variable (set at build/deploy time). When
+ * it is absent, derive the id from the compiled bundle's size+mtime so it
+ * changes only when the bundle changes; fall back to a per-process constant
+ * only when no bundle file is visible (e.g. inside a test process).
+ */
+export function getReleaseId (): string {
+  if (cachedReleaseId !== null) return cachedReleaseId
+
+  const configured = process.env.RELEASE_ID?.trim()
+  if (configured !== undefined && configured !== '') {
+    cachedReleaseId = configured
+    return configured
+  }
+
+  const candidates = [
+    // Bundled: __dirname is dist/, so this is dist/bundle.js itself.
+    path.join(__dirname, 'bundle.js'),
+    // Source/test runs: look in the repo root's dist/ if present.
+    path.join(process.cwd(), 'dist', 'bundle.js')
+  ]
+  for (const file of candidates) {
+    try {
+      if (fs.existsSync(file)) {
+        const stat = fs.statSync(file)
+        cachedReleaseId = `${stat.size.toString(16)}-${Math.floor(stat.mtimeMs).toString(16)}`
+        return cachedReleaseId
+      }
+    } catch {
+      // fall through to the next candidate / final fallback
+    }
+  }
+
+  cachedReleaseId = Date.now().toString(16)
+  return cachedReleaseId
+}

--- a/src/core/utils/routeClass.ts
+++ b/src/core/utils/routeClass.ts
@@ -1,0 +1,67 @@
+/**
+ * Bounded route taxonomy for telemetry.
+ *
+ * Raw URLs, query strings and asset IDs are high-cardinality and are never
+ * recorded; every request is bucketed into one of these fixed classes so
+ * origin capacity questions ("is it crawlers hitting /search/, or bots
+ * hammering PDPs?") can be answered from /metrics without unbounded labels.
+ */
+
+export type RouteClass =
+  | 'health'
+  | 'homepage'
+  | 'browse'
+  | 'search'
+  | 'asset'
+  | 'guides'
+  | 'account'
+  | 'auth'
+  | 'admin'
+  | 'mutation'
+  | 'other'
+
+export const ROUTE_CLASSES: RouteClass[] = [
+  'health',
+  'homepage',
+  'browse',
+  'search',
+  'asset',
+  'guides',
+  'account',
+  'auth',
+  'admin',
+  'mutation',
+  'other'
+]
+
+/** True when the `q` query parameter carries a non-empty text search. */
+function hasSearchQuery (query: Record<string, unknown>): boolean {
+  const raw = query.q
+  if (Array.isArray(raw)) {
+    return raw.some(value => String(value ?? '').trim() !== '')
+  }
+  return String(raw ?? '').trim() !== ''
+}
+
+/**
+ * Classify a request into a fixed, bounded route class for telemetry.
+ * State-changing methods are always `mutation`; everything else is bucketed by
+ * path (canonical browse vs text search is decided by the presence of `q`).
+ */
+export function classifyRouteClass (
+  method: string,
+  path: string,
+  query: Record<string, unknown> = {}
+): RouteClass {
+  if (method !== 'GET' && method !== 'HEAD') return 'mutation'
+  if (path === '/health') return 'health'
+  if (path === '/') return 'homepage'
+  if (path.startsWith('/asset/')) return 'asset'
+  if (path === '/guides' || path.startsWith('/guides/')) return 'guides'
+  if (path.startsWith('/category/') || path.startsWith('/engine/')) return 'browse'
+  if (path.startsWith('/search')) return hasSearchQuery(query) ? 'search' : 'browse'
+  if (path.startsWith('/api/')) return 'auth'
+  if (path.startsWith('/dashboard') || path.startsWith('/register')) return 'account'
+  if (path.startsWith('/admin')) return 'admin'
+  return 'other'
+}

--- a/src/core/utils/telemetry.ts
+++ b/src/core/utils/telemetry.ts
@@ -1,5 +1,7 @@
 import os from 'os'
+import { Server as HttpServer } from 'http'
 import { logger } from 'core/utils/logger'
+import { RouteClass, ROUTE_CLASSES } from 'core/utils/routeClass'
 
 /**
  * Lightweight process-wide telemetry for the HTTP request lifecycle and
@@ -17,6 +19,17 @@ import { logger } from 'core/utils/logger'
  * - A periodic console log line (Docker captures it).
  */
 
+export interface RouteStats {
+  count: number
+  durationSumMs: number
+  durationMinMs: number
+  durationMaxMs: number
+}
+
+function emptyRouteStats (): RouteStats {
+  return { count: 0, durationSumMs: 0, durationMinMs: Number.POSITIVE_INFINITY, durationMaxMs: 0 }
+}
+
 export interface TelemetrySnapshot {
   uptimeSeconds: number
   activeRequests: number
@@ -28,6 +41,11 @@ export interface TelemetrySnapshot {
   cacheMisses: number
   cacheBypasses: number
   cacheErrors: number
+  cacheL1Hits: number
+  cacheStaleHits: number
+  cacheCoalescedWaits: number
+  cacheRefreshes: number
+  cacheRefreshFailures: number
   status2xx: number
   status3xx: number
   status4xx: number
@@ -39,6 +57,11 @@ export interface TelemetrySnapshot {
   durationP50Ms: number
   durationP95Ms: number
   durationP99Ms: number
+  routes: Record<RouteClass, RouteStats>
+  staticRequests: number
+  activeSockets: number
+  eventLoopLagMs: number
+  eventLoopLagMaxMs: number
 }
 
 const DURATION_SAMPLE_LIMIT = 4096
@@ -53,10 +76,25 @@ let cacheHits = 0
 let cacheMisses = 0
 let cacheBypasses = 0
 let cacheErrors = 0
+let cacheL1Hits = 0
+let cacheStaleHits = 0
+let cacheCoalescedWaits = 0
+let cacheRefreshes = 0
+let cacheRefreshFailures = 0
 let status2xx = 0
 let status3xx = 0
 let status4xx = 0
 let status5xx = 0
+let staticRequests = 0
+let activeSockets = 0
+let eventLoopLagMs = 0
+let eventLoopLagMaxMs = 0
+let loopMonitor: NodeJS.Timeout | null = null
+let clusterSnapshot: TelemetrySnapshot | null = null
+
+const routes: Record<RouteClass, RouteStats> = Object.fromEntries(
+  ROUTE_CLASSES.map(cls => [cls, emptyRouteStats()])
+) as Record<RouteClass, RouteStats>
 
 // Bounded ring buffer of recent request durations for percentiles.
 const durations: number[] = []
@@ -64,17 +102,18 @@ let durationSum = 0
 let durationMin = Number.POSITIVE_INFINITY
 let durationMax = 0
 
-/** Record that a dynamic request entered the server. */
-export function requestStart (): void {
+/** Record that a dynamic request entered the server (bucketed by route class). */
+export function requestStart (routeClass: RouteClass = 'other'): void {
   activeRequests++
   totalRequests++
   if (activeRequests > peakActiveRequests) {
     peakActiveRequests = activeRequests
   }
+  routes[routeClass].count++
 }
 
-/** Record a completed (accepted) request: duration and response status class. */
-export function requestEnd (durationMs: number, statusCode: number): void {
+/** Record a completed (accepted) request: duration, status class and route class. */
+export function requestEnd (durationMs: number, statusCode: number, routeClass: RouteClass = 'other'): void {
   if (activeRequests > 0) {
     activeRequests--
   }
@@ -118,6 +157,15 @@ export function requestEnd (durationMs: number, statusCode: number): void {
       }
     }
   }
+
+  const stats = routes[routeClass]
+  stats.durationSumMs += durationMs
+  if (durationMs < stats.durationMinMs) {
+    stats.durationMinMs = durationMs
+  }
+  if (durationMs > stats.durationMaxMs) {
+    stats.durationMaxMs = durationMs
+  }
 }
 
 /** Record a MongoDB driver "timed out checking out a connection" error. */
@@ -146,6 +194,155 @@ export function recordCacheError (): void {
   cacheErrors++
 }
 
+export function recordCacheL1Hit (): void {
+  cacheL1Hits++
+}
+
+export function recordCacheStaleHit (): void {
+  cacheStaleHits++
+}
+
+export function recordCacheCoalescedWait (): void {
+  cacheCoalescedWaits++
+}
+
+export function recordCacheRefresh (): void {
+  cacheRefreshes++
+}
+
+export function recordCacheRefreshFailure (): void {
+  cacheRefreshFailures++
+}
+
+/** Count a static file actually served from disk (wired into express.static setHeaders). */
+export function recordStaticRequest (): void {
+  staticRequests++
+}
+
+/**
+ * Start measuring event-loop lag (delay between when a 1s timer is scheduled
+ * and when it actually fires). A growing lag means the worker is blocked by
+ * CPU-bound work and requests are queueing. Idempotent and unref'd.
+ */
+export function startEventLoopLagMonitor (intervalMs = 1000): void {
+  if (loopMonitor !== null) return
+  let last = process.hrtime.bigint()
+  loopMonitor = setInterval(() => {
+    const now = process.hrtime.bigint()
+    const lagMs = Math.max(0, Number(now - last) / 1e6 - intervalMs)
+    last = now
+    eventLoopLagMs = lagMs
+    if (lagMs > eventLoopLagMaxMs) eventLoopLagMaxMs = lagMs
+  }, intervalMs)
+  loopMonitor.unref()
+}
+
+export function stopEventLoopLagMonitor (): void {
+  if (loopMonitor !== null) {
+    clearInterval(loopMonitor)
+    loopMonitor = null
+  }
+}
+
+/**
+ * Track open TCP sockets on the HTTP server (keep-alive connections count).
+ * Wired once per worker from RouterServer.start.
+ */
+export function trackServerSockets (server: HttpServer): void {
+  server.on('connection', (socket) => {
+    activeSockets++
+    socket.on('close', () => {
+      if (activeSockets > 0) activeSockets--
+    })
+  })
+}
+
+/** Store the latest cluster-wide aggregate so /metrics can include it. */
+export function setClusterSnapshot (snapshot: TelemetrySnapshot | null): void {
+  clusterSnapshot = snapshot
+}
+
+export function getClusterSnapshot (): TelemetrySnapshot | null {
+  return clusterSnapshot
+}
+
+/**
+ * Sum per-worker snapshots into a cluster-wide view for /metrics. Counters are
+ * summed, active/peak gauges take the max, and duration percentiles are
+ * intentionally omitted (they are per-process; each process exposes its own).
+ */
+export function aggregateSnapshots (snapshots: TelemetrySnapshot[]): TelemetrySnapshot {
+  const aggregatedRoutes = Object.fromEntries(
+    ROUTE_CLASSES.map(cls => [cls, emptyRouteStats()])
+  ) as Record<RouteClass, RouteStats>
+  const result: TelemetrySnapshot = {
+    uptimeSeconds: 0,
+    activeRequests: 0,
+    peakActiveRequests: 0,
+    totalRequests: 0,
+    mongoWaitQueueTimeouts: 0,
+    mongoServerSelectionErrors: 0,
+    cacheHits: 0,
+    cacheMisses: 0,
+    cacheBypasses: 0,
+    cacheErrors: 0,
+    cacheL1Hits: 0,
+    cacheStaleHits: 0,
+    cacheCoalescedWaits: 0,
+    cacheRefreshes: 0,
+    cacheRefreshFailures: 0,
+    status2xx: 0,
+    status3xx: 0,
+    status4xx: 0,
+    status5xx: 0,
+    durationCount: 0,
+    durationAvgMs: 0,
+    durationMinMs: 0,
+    durationMaxMs: 0,
+    durationP50Ms: 0,
+    durationP95Ms: 0,
+    durationP99Ms: 0,
+    routes: aggregatedRoutes,
+    staticRequests: 0,
+    activeSockets: 0,
+    eventLoopLagMs: 0,
+    eventLoopLagMaxMs: 0
+  }
+  for (const s of snapshots) {
+    result.activeRequests = Math.max(result.activeRequests, s.activeRequests)
+    result.peakActiveRequests = Math.max(result.peakActiveRequests, s.peakActiveRequests)
+    result.totalRequests += s.totalRequests
+    result.mongoWaitQueueTimeouts += s.mongoWaitQueueTimeouts
+    result.mongoServerSelectionErrors += s.mongoServerSelectionErrors
+    result.cacheHits += s.cacheHits
+    result.cacheMisses += s.cacheMisses
+    result.cacheBypasses += s.cacheBypasses
+    result.cacheErrors += s.cacheErrors
+    result.cacheL1Hits += s.cacheL1Hits
+    result.cacheStaleHits += s.cacheStaleHits
+    result.cacheCoalescedWaits += s.cacheCoalescedWaits
+    result.cacheRefreshes += s.cacheRefreshes
+    result.cacheRefreshFailures += s.cacheRefreshFailures
+    result.status2xx += s.status2xx
+    result.status3xx += s.status3xx
+    result.status4xx += s.status4xx
+    result.status5xx += s.status5xx
+    result.staticRequests += s.staticRequests
+    result.activeSockets += s.activeSockets
+    result.eventLoopLagMs = Math.max(result.eventLoopLagMs, s.eventLoopLagMs)
+    result.eventLoopLagMaxMs = Math.max(result.eventLoopLagMaxMs, s.eventLoopLagMaxMs)
+    for (const cls of ROUTE_CLASSES) {
+      const target = result.routes[cls]
+      const source = s.routes[cls]
+      target.count += source.count
+      target.durationSumMs += source.durationSumMs
+      if (source.durationMinMs < target.durationMinMs) target.durationMinMs = source.durationMinMs
+      if (source.durationMaxMs > target.durationMaxMs) target.durationMaxMs = source.durationMaxMs
+    }
+  }
+  return result
+}
+
 function percentile (p: number): number {
   const count = durations.length
   if (count === 0) {
@@ -169,6 +366,11 @@ export function snapshot (): TelemetrySnapshot {
     cacheMisses,
     cacheBypasses,
     cacheErrors,
+    cacheL1Hits,
+    cacheStaleHits,
+    cacheCoalescedWaits,
+    cacheRefreshes,
+    cacheRefreshFailures,
     status2xx,
     status3xx,
     status4xx,
@@ -179,7 +381,17 @@ export function snapshot (): TelemetrySnapshot {
     durationMaxMs: Math.round(durationMax),
     durationP50Ms: percentile(50),
     durationP95Ms: percentile(95),
-    durationP99Ms: percentile(99)
+    durationP99Ms: percentile(99),
+    // Copy the per-class stats so a snapshot is immutable: callers (and
+    // reset()) can never mutate a snapshot that another process/aggregator is
+    // holding.
+    routes: Object.fromEntries(
+      ROUTE_CLASSES.map(cls => [cls, { ...routes[cls] }])
+    ) as Record<RouteClass, RouteStats>,
+    staticRequests,
+    activeSockets,
+    eventLoopLagMs,
+    eventLoopLagMaxMs
   }
 }
 
@@ -215,6 +427,11 @@ export function prometheusText (): string {
   emit('counter', 'cache_misses_total', 'Shared Dragonfly cache misses filled from the source', s.cacheMisses)
   emit('counter', 'cache_bypasses_total', 'Operations bypassing the shared cache while disabled or unavailable', s.cacheBypasses)
   emit('counter', 'cache_errors_total', 'Shared Dragonfly cache command or payload errors', s.cacheErrors)
+  emit('counter', 'cache_l1_hits_total', 'Per-worker L1 cache hits', s.cacheL1Hits)
+  emit('counter', 'cache_stale_hits_total', 'Responses served from stale-but-valid envelopes', s.cacheStaleHits)
+  emit('counter', 'cache_coalesced_waits_total', 'Requests that awaited an in-flight load instead of running their own', s.cacheCoalescedWaits)
+  emit('counter', 'cache_refreshes_total', 'Background stale-cache refreshes that completed', s.cacheRefreshes)
+  emit('counter', 'cache_refresh_failures_total', 'Background stale-cache refreshes that failed (stale value kept)', s.cacheRefreshFailures)
   emit('gauge', 'process_uptime_seconds', 'Seconds since this process started', s.uptimeSeconds)
   emit('gauge', 'process_rss_bytes', 'Resident set size in bytes', memory.rss)
   emit('gauge', 'process_heap_used_bytes', 'V8 heap used in bytes', memory.heapUsed)
@@ -222,6 +439,34 @@ export function prometheusText (): string {
   emit('gauge', 'system_loadavg_1m', 'System load average over 1 minute', load[0])
   emit('gauge', 'system_loadavg_5m', 'System load average over 5 minutes', load[1])
   emit('gauge', 'system_loadavg_15m', 'System load average over 15 minutes', load[2])
+  emit('counter', 'http_static_requests_total', 'Static files served from disk', s.staticRequests)
+  emit('gauge', 'http_active_sockets', 'Open TCP sockets on this server', s.activeSockets)
+  emit('gauge', 'http_event_loop_lag_ms', 'Latest event-loop lag in ms', s.eventLoopLagMs)
+  emit('gauge', 'http_event_loop_lag_max_ms', 'Max event-loop lag in ms since boot', s.eventLoopLagMaxMs)
+
+  // Bounded per-route-class traffic/latency.
+  for (const cls of ROUTE_CLASSES) {
+    const stats = s.routes[cls]
+    emit('counter', `http_requests_${cls}_total`, `Requests classified as ${cls}`, stats.count)
+    emit('counter', `http_request_duration_ms_${cls}_sum`, `Total response ms for ${cls} requests`, stats.durationSumMs)
+    emit('gauge', `http_request_duration_ms_${cls}_avg`, `Average response ms for ${cls} requests`, stats.count > 0 ? Math.round(stats.durationSumMs / stats.count) : 0)
+    emit('gauge', `http_request_duration_ms_${cls}_max`, `Max response ms for a ${cls} request`, Number.isFinite(stats.durationMaxMs) ? stats.durationMaxMs : 0)
+  }
+
+  // Cluster-wide view aggregated by the primary over IPC (present on every worker).
+  if (clusterSnapshot !== null) {
+    const c = clusterSnapshot
+    emit('counter', 'http_cluster_requests_total', 'Aggregate requests across the whole cluster (primary IPC aggregation)', c.totalRequests)
+    emit('gauge', 'http_cluster_active_requests', 'Aggregate in-flight requests across the cluster', c.activeRequests)
+    emit('counter', 'http_cluster_2xx_total', 'Aggregate 2xx responses across the cluster', c.status2xx)
+    emit('counter', 'http_cluster_4xx_total', 'Aggregate 4xx responses across the cluster', c.status4xx)
+    emit('counter', 'http_cluster_5xx_total', 'Aggregate 5xx responses across the cluster', c.status5xx)
+    emit('counter', 'http_cluster_cache_hits_total', 'Aggregate Dragonfly cache hits across the cluster', c.cacheHits)
+    emit('counter', 'http_cluster_cache_stale_hits_total', 'Aggregate stale-cache serves across the cluster', c.cacheStaleHits)
+    emit('counter', 'http_cluster_mongo_wait_queue_timeouts_total', 'Aggregate Mongo wait-queue timeouts across the cluster', c.mongoWaitQueueTimeouts)
+    emit('counter', 'http_cluster_mongo_server_selection_errors_total', 'Aggregate Mongo server-selection errors across the cluster', c.mongoServerSelectionErrors)
+    emit('gauge', 'http_cluster_event_loop_lag_max_ms', 'Max event-loop lag in ms across the cluster', c.eventLoopLagMaxMs)
+  }
 
   return `${lines.join('\n')}\n`
 }
@@ -265,6 +510,11 @@ export function reset (): void {
   cacheMisses = 0
   cacheBypasses = 0
   cacheErrors = 0
+  cacheL1Hits = 0
+  cacheStaleHits = 0
+  cacheCoalescedWaits = 0
+  cacheRefreshes = 0
+  cacheRefreshFailures = 0
   status2xx = 0
   status3xx = 0
   status4xx = 0
@@ -273,4 +523,12 @@ export function reset (): void {
   durationSum = 0
   durationMin = Number.POSITIVE_INFINITY
   durationMax = 0
+  staticRequests = 0
+  activeSockets = 0
+  eventLoopLagMs = 0
+  eventLoopLagMaxMs = 0
+  clusterSnapshot = null
+  for (const cls of ROUTE_CLASSES) {
+    routes[cls] = emptyRouteStats()
+  }
 }

--- a/src/core/utils/telemetry.ts
+++ b/src/core/utils/telemetry.ts
@@ -267,9 +267,10 @@ export function getClusterSnapshot (): TelemetrySnapshot | null {
 }
 
 /**
- * Sum per-worker snapshots into a cluster-wide view for /metrics. Counters are
- * summed, active/peak gauges take the max, and duration percentiles are
- * intentionally omitted (they are per-process; each process exposes its own).
+ * Sum per-worker snapshots into a cluster-wide view for /metrics. Counters and
+ * the active-request gauge are summed (cluster aggregate load), peak gauges
+ * take the max, and duration percentiles are intentionally omitted (they are
+ * per-process; each process exposes its own).
  */
 export function aggregateSnapshots (snapshots: TelemetrySnapshot[]): TelemetrySnapshot {
   const aggregatedRoutes = Object.fromEntries(
@@ -309,7 +310,7 @@ export function aggregateSnapshots (snapshots: TelemetrySnapshot[]): TelemetrySn
     eventLoopLagMaxMs: 0
   }
   for (const s of snapshots) {
-    result.activeRequests = Math.max(result.activeRequests, s.activeRequests)
+    result.activeRequests += s.activeRequests
     result.peakActiveRequests = Math.max(result.peakActiveRequests, s.peakActiveRequests)
     result.totalRequests += s.totalRequests
     result.mongoWaitQueueTimeouts += s.mongoWaitQueueTimeouts
@@ -424,7 +425,7 @@ export function prometheusText (): string {
   emit('counter', 'mongo_wait_queue_timeouts_total', 'MongoDB connection checkout (wait-queue) timeouts', s.mongoWaitQueueTimeouts)
   emit('counter', 'mongo_server_selection_errors_total', 'MongoDB server-selection errors', s.mongoServerSelectionErrors)
   emit('counter', 'cache_hits_total', 'Shared Dragonfly cache hits', s.cacheHits)
-  emit('counter', 'cache_misses_total', 'Shared Dragonfly cache misses filled from the source', s.cacheMisses)
+  emit('counter', 'cache_misses_total', 'Cache loads that fell through to the source (misses, or bypasses while the shared cache is disabled/unavailable)', s.cacheMisses)
   emit('counter', 'cache_bypasses_total', 'Operations bypassing the shared cache while disabled or unavailable', s.cacheBypasses)
   emit('counter', 'cache_errors_total', 'Shared Dragonfly cache command or payload errors', s.cacheErrors)
   emit('counter', 'cache_l1_hits_total', 'Per-worker L1 cache hits', s.cacheL1Hits)

--- a/tests/cluster-config.test.ts
+++ b/tests/cluster-config.test.ts
@@ -1,6 +1,11 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { getWorkerCount, getDefaultMongoPool } from '../src/core/utils/clusterConfig'
+import {
+  getWorkerCount,
+  getDefaultMongoPool,
+  getPrimaryMongoPool,
+  DEFAULT_TOTAL_POOL_BUDGET
+} from '../src/core/utils/clusterConfig'
 
 /**
  * Run a check with a specific WORKER_COUNT and restore the previous value
@@ -54,17 +59,36 @@ describe('clusterConfig', () => {
 
   it('scales the default Mongo pool per process to keep the total bounded', () => {
     withWorkerCount('4', () => {
-      // 1500 / (4 workers + 1 primary) = 300 per process, so the whole cluster
-      // (workers + primary) stays ~1500 worst-case.
+      // 1500 / (4 workers + 1 primary) = 300 per process.
       assert.equal(getDefaultMongoPool(), 300)
     })
     withWorkerCount('2', () => {
       // 1500 / (2 workers + 1 primary) = 500 per process.
       assert.equal(getDefaultMongoPool(), 500)
     })
-    // Never below the 200 floor, even with many workers.
+    // No 200-per-process floor: 16 workers -> 1500/17 = 88 per process, so the
+    // aggregate (workers + primary) never exceeds the total budget.
     withWorkerCount('16', () => {
-      assert.equal(getDefaultMongoPool(), 200)
+      assert.equal(getDefaultMongoPool(), 88)
+    })
+  })
+
+  it('never lets the aggregate worker+primary pool exceed the total budget', () => {
+    for (const count of ['1', '2', '3', '4', '6', '7', '8', '12', '16']) {
+      withWorkerCount(count, () => {
+        const workers = getWorkerCount()
+        const total = (workers + 1) * getDefaultMongoPool()
+        assert.ok(total <= DEFAULT_TOTAL_POOL_BUDGET, `workers=${workers} total=${total}`)
+      })
+    }
+  })
+
+  it('sizes the primary (job-only) pool much smaller than workers', () => {
+    withWorkerCount('4', () => {
+      assert.equal(getPrimaryMongoPool(), 75)
+    })
+    withWorkerCount('16', () => {
+      assert.equal(getPrimaryMongoPool(), 22)
     })
   })
 })

--- a/tests/dragonfly-cache.test.ts
+++ b/tests/dragonfly-cache.test.ts
@@ -4,7 +4,12 @@ import {
   cacheGetOrLoad,
   buildAssetCacheKey,
   buildAllAssetCacheKeys,
-  buildUserContextCacheKey
+  buildUserContextCacheKey,
+  buildAssetEpochKey,
+  buildEnvelope,
+  isEnvelopeFresh,
+  isEnvelopeStaleServable,
+  getAssetEpoch
 } from '../src/core/utils/dragonfly'
 import { reset, snapshot } from '../src/core/utils/telemetry'
 
@@ -58,5 +63,50 @@ describe('Dragonfly cache', () => {
   it('builds a stable user context cache key', () => {
     assert.equal(buildUserContextCacheKey('tok-1'), 'gda:v1:userctx:tok-1')
     assert.equal(buildUserContextCacheKey('tok-1'), buildUserContextCacheKey('tok-1'))
+  })
+})
+
+describe('cache envelopes', () => {
+  it('marks envelopes fresh until freshUntil and stale-servable inside the stale window', () => {
+    const now = 1_000_000
+    const envelope = buildEnvelope({ ok: true }, 5000, 86_400_000, now)
+    assert.equal(isEnvelopeFresh(envelope, now), true)
+    assert.equal(isEnvelopeStaleServable(envelope, now), false)
+    // Past the fresh window, within the stale window -> servable stale.
+    assert.equal(isEnvelopeFresh(envelope, now + 5001), false)
+    assert.equal(isEnvelopeStaleServable(envelope, now + 5001), true)
+    // Past the stale window -> not servable at all.
+    assert.equal(isEnvelopeFresh(envelope, now + 5000 + 86_400_000), false)
+    assert.equal(isEnvelopeStaleServable(envelope, now + 5000 + 86_400_000), false)
+  })
+
+  it('collapses the stale window when the stale TTL is zero', () => {
+    const now = 1_000_000
+    const envelope = buildEnvelope({ ok: true }, 3000, 0, now)
+    assert.equal(isEnvelopeFresh(envelope, now + 2999), true)
+    assert.equal(isEnvelopeFresh(envelope, now + 3000), false)
+    assert.equal(isEnvelopeStaleServable(envelope, now + 3000), false)
+  })
+})
+
+describe('asset epoch keys', () => {
+  it('builds a stable per-asset epoch key', () => {
+    assert.equal(buildAssetEpochKey('abc-123'), 'gda:v2:assetepoch:abc-123')
+    assert.equal(buildAssetEpochKey('abc-123'), buildAssetEpochKey('abc-123'))
+    assert.notEqual(buildAssetEpochKey('abc-123'), buildAssetEpochKey('xyz-456'))
+  })
+
+  it('returns null for the asset epoch while the cache is disabled (fail-open)', async () => {
+    const previous = process.env.CACHE_ENABLED
+    process.env.CACHE_ENABLED = 'false'
+    try {
+      assert.equal(await getAssetEpoch('abc-123'), null)
+    } finally {
+      if (previous === undefined) {
+        delete process.env.CACHE_ENABLED
+      } else {
+        process.env.CACHE_ENABLED = previous
+      }
+    }
   })
 })

--- a/tests/ensure-indexes.test.ts
+++ b/tests/ensure-indexes.test.ts
@@ -1,0 +1,66 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { ensureIndexes } from '../src/core/ensureIndexes'
+
+interface FakeCollection {
+  createIndex: (key: Record<string, unknown>) => Promise<string>
+  indexes: () => Promise<Array<{ key: Record<string, unknown> }>>
+}
+
+/**
+ * A fake db whose collections record every createIndex attempt. Any label in
+ * `failLabels` (e.g. "assets.godot_version") throws, so the test can prove a
+ * failing index never aborts the remaining ones.
+ */
+function makeFakeDb (failLabels: Set<string>): { db: any, attempted: string[], created: string[] } {
+  const attempted: string[] = []
+  const created: string[] = []
+  const makeCollection = (name: string): FakeCollection => ({
+    createIndex: async (key: Record<string, unknown>) => {
+      const label = `${name}.${Object.keys(key)[0] ?? ''}`
+      attempted.push(label)
+      if (failLabels.has(label)) {
+        throw new Error(`boom on ${label}`)
+      }
+      created.push(label)
+      return label
+    },
+    // A text index exists, so the post-loop verification logs "verified".
+    indexes: async () => [{ key: { title: 'text' } }]
+  })
+  const db = { collection: (name: string): FakeCollection => makeCollection(name) }
+  return { db, attempted, created }
+}
+
+describe('ensureIndexes', () => {
+  it('attempts every index even when one fails', async () => {
+    const { db, attempted, created } = makeFakeDb(new Set(['assets.godot_version']))
+    await ensureIndexes(db)
+
+    // Indexes before AND after the failing one are all attempted.
+    assert.ok(attempted.includes('assets.asset_id'))
+    assert.ok(attempted.includes('assets.godot_version'))
+    assert.ok(attempted.includes('assets.rating_score'))
+    assert.ok(attempted.includes('users.username'))
+    assert.ok(attempted.includes('reviews.asset_id'))
+    assert.ok(attempted.includes('reports.human_id'))
+    // The LAST index still runs despite earlier failures.
+    assert.ok(attempted.includes('info.type'))
+
+    // The failing index was attempted but not created; every other one was.
+    assert.ok(!created.includes('assets.godot_version'))
+    assert.equal(created.length, attempted.length - 1)
+  })
+
+  it('never throws and keeps going with multiple failures', async () => {
+    const { db, attempted, created } = makeFakeDb(new Set(['assets.featured', 'users.username', 'reviews.human_id']))
+    await ensureIndexes(db) // must resolve, never reject
+
+    for (const failed of ['assets.featured', 'users.username', 'reviews.human_id']) {
+      assert.ok(attempted.includes(failed))
+      assert.ok(!created.includes(failed))
+    }
+    assert.ok(attempted.includes('info.type'))
+    assert.equal(created.length, attempted.length - 3)
+  })
+})

--- a/tests/http-cache-policy.test.ts
+++ b/tests/http-cache-policy.test.ts
@@ -1,0 +1,95 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  classifyCacheControl,
+  isPubliclyCacheablePath,
+  buildPublicCacheControl,
+  PUBLIC_CACHE_POLICY
+} from '../src/core/utils/httpCachePolicy'
+
+function req (
+  method: string,
+  path: string,
+  query: Record<string, unknown> = {},
+  cookies: Record<string, unknown> = {}
+): { method: string, path: string, query: Record<string, unknown>, cookies: Record<string, unknown> } {
+  return { method, path, query, cookies }
+}
+
+describe('isPubliclyCacheablePath', () => {
+  it('allows the canonical anonymous public views', () => {
+    assert.equal(isPubliclyCacheablePath('GET', '/', {}), true)
+    assert.equal(isPubliclyCacheablePath('GET', '/search/', {}), true)
+    assert.equal(isPubliclyCacheablePath('GET', '/search/', { page: '2' }), true)
+    assert.equal(isPubliclyCacheablePath('GET', '/category/2d%20tools', {}), true)
+    assert.equal(isPubliclyCacheablePath('GET', '/category/2d%20tools', { page: '3' }), true)
+    assert.equal(isPubliclyCacheablePath('GET', '/engine/3.4', {}), true)
+    assert.equal(isPubliclyCacheablePath('GET', '/asset/abc-123/my-slug', {}), true)
+    assert.equal(isPubliclyCacheablePath('GET', '/guides', {}), true)
+    assert.equal(isPubliclyCacheablePath('GET', '/guides/some-guide', {}), true)
+    assert.equal(isPubliclyCacheablePath('GET', '/guides/feed.xml', {}), true)
+  })
+
+  it('rejects search queries, filters, sort, limit and out-of-range pagination', () => {
+    assert.equal(isPubliclyCacheablePath('GET', '/search/', { q: 'shader' }), false)
+    assert.equal(isPubliclyCacheablePath('GET', '/search/', { category: 'shaders' }), false)
+    assert.equal(isPubliclyCacheablePath('GET', '/search/', { sort: 'asset_rating' }), false)
+    assert.equal(isPubliclyCacheablePath('GET', '/search/', { limit: '24' }), false)
+    assert.equal(isPubliclyCacheablePath('GET', '/search/', { page: '0' }), false)
+    assert.equal(isPubliclyCacheablePath('GET', '/search/', { page: 'abc' }), false)
+    assert.equal(isPubliclyCacheablePath('GET', '/search/', { page: '1001' }), false)
+    assert.equal(isPubliclyCacheablePath('GET', '/category/2d%20tools', { sort: 'asset_rating' }), false)
+    assert.equal(isPubliclyCacheablePath('GET', '/category/2d%20tools', { page: '0' }), false)
+    assert.equal(isPubliclyCacheablePath('GET', '/engine/3.4', { q: 'x' }), false)
+  })
+
+  it('rejects request-specific asset and guide variants', () => {
+    assert.equal(isPubliclyCacheablePath('GET', '/asset/abc-123/my-slug', { from: '/search/' }), false)
+    assert.equal(isPubliclyCacheablePath('GET', '/asset/abc-123/my-slug', { reviews_page: '1' }), false)
+    assert.equal(isPubliclyCacheablePath('GET', '/guides/some-guide', { foo: 'bar' }), false)
+  })
+
+  it('rejects non-GET/HEAD methods, unknown paths and protected namespaces', () => {
+    assert.equal(isPubliclyCacheablePath('POST', '/', {}), false)
+    assert.equal(isPubliclyCacheablePath('HEAD', '/', {}), true)
+    assert.equal(isPubliclyCacheablePath('GET', '/foo', {}), false)
+    assert.equal(isPubliclyCacheablePath('GET', '/dashboard', {}), false)
+  })
+})
+
+describe('classifyCacheControl', () => {
+  it('applies the aggressive public policy to eligible anonymous requests', () => {
+    assert.equal(classifyCacheControl(req('GET', '/', {})), buildPublicCacheControl())
+    assert.equal(classifyCacheControl(req('GET', '/asset/abc-123/my-slug', {})), buildPublicCacheControl())
+    assert.equal(classifyCacheControl(req('GET', '/search/', { page: '2' })), buildPublicCacheControl())
+  })
+
+  it('keeps version-cookie requests browser-only, not shared', () => {
+    assert.equal(classifyCacheControl(req('GET', '/', {}, { godot_version: '3' })), 'private, max-age=120')
+  })
+
+  it('marks authenticated requests private no-store', () => {
+    assert.equal(classifyCacheControl(req('GET', '/', {}, { 'auth-token': 'tok' })), 'private, no-store')
+  })
+
+  it('keeps anonymous non-eligible GETs browser-only, not shared', () => {
+    assert.equal(classifyCacheControl(req('GET', '/search/', { q: 'shader' })), 'private, max-age=120')
+    assert.equal(classifyCacheControl(req('GET', '/foo', {})), 'private, max-age=120')
+  })
+
+  it('leaves non-GET/HEAD requests alone', () => {
+    assert.equal(classifyCacheControl(req('POST', '/', {})), null)
+    assert.equal(classifyCacheControl(req('PATCH', '/asset/x', {})), null)
+  })
+})
+
+describe('buildPublicCacheControl', () => {
+  it('emits the five-minute shared / 24h stale policy', () => {
+    const out = buildPublicCacheControl()
+    assert.ok(out.startsWith('public, max-age=60, s-maxage=300'), out)
+    assert.ok(out.includes('stale-while-revalidate=300'), out)
+    assert.ok(out.includes('stale-if-error=86400'), out)
+    assert.equal(PUBLIC_CACHE_POLICY.sharedMaxAge, 300)
+    assert.equal(PUBLIC_CACHE_POLICY.staleIfError, 86_400)
+  })
+})

--- a/tests/is-public-migration.test.ts
+++ b/tests/is-public-migration.test.ts
@@ -1,0 +1,42 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { backfillIsPublic } from '../src/core/migrations/0006-backfill-is-public'
+
+interface UpdateCall {
+  filter: Record<string, unknown>
+  update: Record<string, unknown>
+}
+
+function makeFakeDb (): { db: any, calls: UpdateCall[] } {
+  const calls: UpdateCall[] = []
+  const assets = {
+    updateMany: async (filter: Record<string, unknown>, update: Record<string, unknown>): Promise<{ modifiedCount: number }> => {
+      calls.push({ filter, update })
+      return { modifiedCount: 1 }
+    }
+  }
+  const db = { collection: (name: string): unknown => (name === 'assets' ? assets : {}) }
+  return { db, calls }
+}
+
+describe('backfillIsPublic', () => {
+  it('marks hidden assets not public and the rest public, touching only docs missing the field', async () => {
+    const { db, calls } = makeFakeDb()
+    await backfillIsPublic(db)
+
+    assert.equal(calls.length, 2)
+    // Hidden: unavailable OR non-searchable, only where is_public is absent.
+    assert.deepEqual(calls[0].filter, {
+      is_public: { $exists: false },
+      $or: [{ source_status: 'unavailable' }, { searchable: 'false' }]
+    })
+    assert.deepEqual(calls[0].update, { $set: { is_public: false } })
+    // Public: everything else missing the field (matches legacy $ne semantics).
+    assert.deepEqual(calls[1].filter, {
+      is_public: { $exists: false },
+      source_status: { $ne: 'unavailable' },
+      searchable: { $ne: 'false' }
+    })
+    assert.deepEqual(calls[1].update, { $set: { is_public: true } })
+  })
+})

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -35,8 +35,8 @@ describe('runMigrations', () => {
   it('records every migration when all succeed', async () => {
     const { db, recorded } = makeFakeDb()
     const migrations: Migration[] = [
-      { id: 'a', description: 'A', run: async () => {} },
-      { id: 'b', description: 'B', run: async () => {} }
+      { id: 'a', description: 'A', run: async () => { } },
+      { id: 'b', description: 'B', run: async () => { } }
     ]
 
     await runMigrations(db, migrations)

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -1,0 +1,95 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { runMigrations, Migration } from '../src/core/migrations'
+
+interface FakeCollection {
+  findOne: (query: { id: string }) => Promise<{ id: string, applied_at: Date } | null>
+  insertOne: (doc: { id: string, applied_at: Date }) => Promise<void>
+}
+
+/**
+ * A minimal stand-in for the Mongo `Db`/collection that `runMigrations`
+ * touches (`migrations` only), so the runner can be tested without a server.
+ */
+function makeFakeDb (applied = new Map<string, Date>()): {
+  db: any
+  applied: Map<string, Date>
+  recorded: string[]
+} {
+  const recorded: string[] = []
+  const collection: FakeCollection = {
+    findOne: async (query) => {
+      const appliedAt = applied.get(query.id)
+      return appliedAt !== undefined ? { id: query.id, applied_at: appliedAt } : null
+    },
+    insertOne: async (doc) => {
+      applied.set(doc.id, doc.applied_at)
+      recorded.push(doc.id)
+    }
+  }
+  const db = { collection: (name: string) => (name === 'migrations' ? collection : {}) }
+  return { db, applied, recorded }
+}
+
+describe('runMigrations', () => {
+  it('records every migration when all succeed', async () => {
+    const { db, recorded } = makeFakeDb()
+    const migrations: Migration[] = [
+      { id: 'a', description: 'A', run: async () => {} },
+      { id: 'b', description: 'B', run: async () => {} }
+    ]
+
+    await runMigrations(db, migrations)
+
+    assert.deepEqual(recorded, ['a', 'b'])
+  })
+
+  it('runs every migration independently when one fails', async () => {
+    const { db, applied, recorded } = makeFakeDb()
+    const runs: string[] = []
+    const migrations: Migration[] = [
+      { id: 'a', description: 'A', run: async () => { runs.push('a') } },
+      { id: 'b', description: 'B', run: async () => { runs.push('b'); throw new Error('boom') } },
+      { id: 'c', description: 'C', run: async () => { runs.push('c') } }
+    ]
+
+    await assert.rejects(
+      runMigrations(db, migrations),
+      /b/
+    )
+
+    // The failing migration must not prevent its neighbours from running.
+    assert.deepEqual(runs, ['a', 'b', 'c'])
+    // Successful migrations are recorded; the failed one is not, so it retries next run.
+    assert.deepEqual(recorded, ['a', 'c'])
+    assert.equal(applied.has('b'), false)
+  })
+
+  it('names every failing migration in the aggregate error', async () => {
+    const { db } = makeFakeDb()
+    const migrations: Migration[] = [
+      { id: 'a', description: 'A', run: async () => { throw new Error('x') } },
+      { id: 'b', description: 'B', run: async () => { throw new Error('y') } }
+    ]
+
+    await assert.rejects(
+      runMigrations(db, migrations),
+      /a.*b/
+    )
+  })
+
+  it('skips already-applied migrations without running them', async () => {
+    const applied = new Map<string, Date>([['a', new Date()]])
+    const { db, recorded } = makeFakeDb(applied)
+    const runs: string[] = []
+    const migrations: Migration[] = [
+      { id: 'a', description: 'A', run: async () => { runs.push('a') } },
+      { id: 'b', description: 'B', run: async () => { runs.push('b') } }
+    ]
+
+    await runMigrations(db, migrations)
+
+    assert.deepEqual(runs, ['b'])
+    assert.deepEqual(recorded, ['b'])
+  })
+})

--- a/tests/route-class.test.ts
+++ b/tests/route-class.test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { classifyRouteClass, ROUTE_CLASSES } from '../src/core/utils/routeClass'
+
+describe('classifyRouteClass', () => {
+  it('buckets state-changing methods as mutation', () => {
+    assert.equal(classifyRouteClass('POST', '/'), 'mutation')
+    assert.equal(classifyRouteClass('PATCH', '/asset/x'), 'mutation')
+    assert.equal(classifyRouteClass('DELETE', '/dashboard/account'), 'mutation')
+  })
+
+  it('classifies public discovery routes', () => {
+    assert.equal(classifyRouteClass('GET', '/'), 'homepage')
+    assert.equal(classifyRouteClass('GET', '/health'), 'health')
+    assert.equal(classifyRouteClass('GET', '/search/'), 'browse')
+    assert.equal(classifyRouteClass('GET', '/search/', { page: '2' }), 'browse')
+    assert.equal(classifyRouteClass('GET', '/search/', { q: 'shader' }), 'search')
+    assert.equal(classifyRouteClass('GET', '/search/', { q: '  ' }), 'browse')
+    assert.equal(classifyRouteClass('GET', '/category/2d%20tools'), 'browse')
+    assert.equal(classifyRouteClass('GET', '/engine/3.4'), 'browse')
+    assert.equal(classifyRouteClass('GET', '/asset/abc-123/my-slug'), 'asset')
+    assert.equal(classifyRouteClass('GET', '/guides'), 'guides')
+    assert.equal(classifyRouteClass('GET', '/guides/some-guide'), 'guides')
+  })
+
+  it('classifies account/auth/admin and falls back to other', () => {
+    assert.equal(classifyRouteClass('GET', '/dashboard'), 'account')
+    assert.equal(classifyRouteClass('GET', '/register'), 'account')
+    assert.equal(classifyRouteClass('GET', '/api/users/login'), 'auth')
+    assert.equal(classifyRouteClass('GET', '/admin'), 'admin')
+    assert.equal(classifyRouteClass('GET', '/robots.txt'), 'other')
+    assert.equal(classifyRouteClass('GET', '/some-custom-path'), 'other')
+  })
+
+  it('exposes a fixed bounded set of classes', () => {
+    assert.ok(ROUTE_CLASSES.length > 0)
+    assert.ok(ROUTE_CLASSES.includes('homepage'))
+    assert.ok(ROUTE_CLASSES.includes('search'))
+  })
+})

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -239,8 +239,7 @@ describe('buildSearchFilter with the version pin', () => {
     assert.equal(filter.godot_major, 4)
     assert.equal(filter.godot_version, undefined)
     // PUBLIC_ASSET_FILTER always stays applied.
-    assert.deepEqual(filter.source_status, { $ne: 'unavailable' })
-    assert.deepEqual(filter.searchable, { $ne: 'false' })
+    assert.equal(filter.is_public, true)
   })
 
   it('drops the major when an exact engine selection is present', () => {
@@ -253,6 +252,6 @@ describe('buildSearchFilter with the version pin', () => {
     const filter = buildSearchFilter('shader', { godotMajor: 3 })
     assert.equal(filter.godot_major, 3)
     assert.deepEqual(filter.$text, { $search: 'shader', $caseSensitive: false })
-    assert.deepEqual(filter.source_status, PUBLIC_ASSET_FILTER.source_status)
+    assert.equal(filter.is_public, PUBLIC_ASSET_FILTER.is_public)
   })
 })

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -93,11 +93,8 @@ describe('safeJsonLd', () => {
 })
 
 describe('PUBLIC_ASSET_FILTER', () => {
-  it('excludes unavailable and non-searchable assets', () => {
-    assert.deepEqual(PUBLIC_ASSET_FILTER, {
-      source_status: { $ne: 'unavailable' },
-      searchable: { $ne: 'false' }
-    })
+  it('selects only denormalized public assets via an indexed equality', () => {
+    assert.deepEqual(PUBLIC_ASSET_FILTER, { is_public: true })
   })
 })
 

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -10,6 +10,9 @@ import {
   recordCacheMiss,
   recordCacheBypass,
   recordCacheError,
+  recordStaticRequest,
+  setClusterSnapshot,
+  aggregateSnapshots,
   prometheusText,
   reset
 } from '../src/core/utils/telemetry'
@@ -104,5 +107,62 @@ describe('telemetry', () => {
     assert.match(text, /http_request_duration_p95_ms 5/)
     assert.match(text, /mongo_wait_queue_timeouts_total 0/)
     assert.match(text, /cache_hits_total 0/)
+  })
+
+  it('tracks per-route-class traffic and latency', () => {
+    reset()
+    requestStart('homepage')
+    requestEnd(10, 200, 'homepage')
+    requestStart('search')
+    requestEnd(250, 200, 'search')
+    const s = snapshot()
+    assert.equal(s.routes.homepage.count, 1)
+    assert.equal(s.routes.homepage.durationSumMs, 10)
+    assert.equal(s.routes.search.count, 1)
+    assert.equal(s.routes.search.durationSumMs, 250)
+    // The no-arg default bucket is 'other'.
+    assert.equal(s.routes.other.count, 0)
+  })
+
+  it('counts static file serves', () => {
+    reset()
+    recordStaticRequest()
+    recordStaticRequest()
+    assert.equal(snapshot().staticRequests, 2)
+  })
+
+  it('aggregates worker snapshots into a cluster view', () => {
+    reset()
+    requestStart('homepage')
+    requestEnd(10, 200, 'homepage')
+    const a = snapshot()
+    reset()
+    requestStart('search')
+    requestEnd(20, 404, 'search')
+    const b = snapshot()
+    const cluster = aggregateSnapshots([a, b])
+    assert.equal(cluster.totalRequests, 2)
+    assert.equal(cluster.routes.homepage.count, 1)
+    assert.equal(cluster.routes.search.count, 1)
+    assert.equal(cluster.status2xx, 1)
+    assert.equal(cluster.status4xx, 1)
+  })
+
+  it('renders route-class, static and cluster metrics in Prometheus text', () => {
+    reset()
+    requestStart('homepage')
+    requestEnd(5, 200, 'homepage')
+    recordStaticRequest()
+    const perProcess = prometheusText()
+    assert.match(perProcess, /http_requests_homepage_total 1/)
+    assert.match(perProcess, /http_static_requests_total 1/)
+    assert.match(perProcess, /http_active_sockets/)
+    assert.match(perProcess, /http_event_loop_lag_ms/)
+    // The cluster block appears once a cluster snapshot is stored.
+    setClusterSnapshot(aggregateSnapshots([snapshot()]))
+    const withCluster = prometheusText()
+    assert.match(withCluster, /http_cluster_requests_total 1/)
+    assert.match(withCluster, /http_cluster_2xx_total 1/)
+    reset()
   })
 })

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -148,6 +148,19 @@ describe('telemetry', () => {
     assert.equal(cluster.status4xx, 1)
   })
 
+  it('sums the active-request gauge across workers', () => {
+    reset()
+    requestStart('homepage')
+    requestStart('asset')
+    const a = snapshot()
+    reset()
+    requestStart('search')
+    const b = snapshot()
+    const cluster = aggregateSnapshots([a, b])
+    assert.equal(cluster.activeRequests, 3)
+    reset()
+  })
+
   it('renders route-class, static and cluster metrics in Prometheus text', () => {
     reset()
     requestStart('homepage')


### PR DESCRIPTION
### Goal:
Make the origin resilient to extreme/attack traffic so anonymous public pages
are almost entirely absorbed by Cloudflare and the edge, while the origin
survives cache/database outages and scales without falling over.

Concretely, this MR:
- Adds aggressive, safe HTTP edge caching (cache-control policy for anonymous
  canonical pages; stable release-id cache busters; one-year immutable static;
  no-store on errors/404s) so a CDN can absorb the bulk of repeat traffic.
- Rebuilds the origin cache as a stale-capable two-tier (per-worker L1 +
  shared Dragonfly) cache with single-flight coalescing, atomic lock release,
  epoch-fenced invalidation, and 24h stale serving — so a Mongo/Dragonfly
  outage serves the last known good page instead of failing.
- Cuts cold-miss database cost: bounded Mongo pool budget, indexable
  `$match`-first search facets, canonical `category_lowercase` related-assets,
  measured discovery/review indexes, a denormalized `is_public` catalog flag,
  and an `npm run audit:queries` explain baseline tool.
- Hardens the HTTP lifecycle: env-tunable server timeouts, graceful worker
  drain + primary shutdown wait, and a pre-fork `is_public` safety check.
- Adds capacity observability: route-class metrics, event-loop/socket/static
  gauges, and a cluster-wide `/metrics` view aggregated over IPC, plus a
  runbook and a dependency-free `npm run loadtest` harness.
- Hardens deployment: multi-stage non-root Docker image, prod-dependency
  classification, Dragonfly 1GiB + fail-open startup, Mongo readiness gating,
  log rotation/init/stop-grace, and full env documentation.

### Checklist
- [x] The changes are scoped appropriately
- [x] The project builds and runs successfully
- [x] I have self reviewed the changes